### PR TITLE
ci: Publish to pypi.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,17 @@
+# Do not rename this file. It is used by name in the trusted publisher section
+# in pypi.org and test.pypi.org
+
 name: CI
 
 on:
   push:
-    branches: ["**"] # For now, let's build all branches. Roll this back if it gets too slow or we exhaust our quota.
+    branches:
+    - '**' # For now, let's build all branches. Roll this back if it gets too slow or we exhaust our quota.
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+' # Build v1.2.3 tags as well. We'll use tags as the criteria for publishing
   pull_request:
-    branches: ["**"] # * does not match '/'
+    branches:
+    - '**' # * does not match '/' like sm/my-feature
   workflow_dispatch: # For manually triggering a build: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch
 
 jobs:
@@ -25,34 +32,107 @@ jobs:
       # Build (and test) Lean. Tests are all via #guard macros
       # now so you can't really build without testing.
       - uses: leanprover/lean-action@v1
-      - name: Run tests
+
+      - name: Run Lean tests
         run: lake exe klr
-      # Run pytest
-      - uses: actions/setup-python@v5
+
+      - name: Install Python
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
           cache: 'pip'
+
       - name: Install dependencies
         working-directory: ./interop
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+
       - name: Run pytest
         working-directory: ./interop
         run: |
           pytest
-      - name: Make a wheel
-        # https://github.com/pypa/cibuildwheel
-        # Hit this: https://github.com/pypa/cibuildwheel/discussions/1926
-        env:
-          # https://github.com/leanprover/lean4/pull/6631/files
-          MACOSX_DEPLOYMENT_TARGET: 99.0
-          CIBW_BUILD_VERBOSITY: 1
-          CIBW_SKIP: 'pp* *-win32 *-manylinux_i686 *-musllinux_*' # The build doesn't work 686 or musl
-        run: |
-          pip install cibuildwheel
-          bin/make-wheel
-      - uses: actions/upload-artifact@v4
-        with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-          path: ./.wheel/wheelhouse/*.whl
+
+  # Mostly followed guides here:
+  # - https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file
+  # - https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+  # NB: I needed to set the trusted publisher to repo NKL, not KLR, since that was its original name. Scary detail! No idea how I'd figure that out without knowing the original name.
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+    - build
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to pypi on tag pushes
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - uses: actions/checkout@v4 # for scripts
+
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        # name: python-package-distributions
+        # # unpacks all CIBW artifacts into dist/
+        # pattern: cibw-*
+        path: dist/
+        merge-multiple: true
+
+    - name: List the wheels
+      run: |
+        ls -1 dist/
+
+    - name: Rename OSX wheels
+      working-directory: ./dist
+      run: ../bin/rename-wheels # .. because we are starting in ./dist
+
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        verbose: true
+        skip-existing: true
+
+  # For this step to succeed, you must have bumped the klr version in interop/pyproject.toml
+  publish-to-pypi:
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    needs:
+    - build
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to pypi on tag pushes
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - uses: actions/checkout@v4 # for scripts
+
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        # name: python-package-distributions
+        # # unpacks all CIBW artifacts into dist/
+        # pattern: cibw-*
+        path: dist/
+        merge-multiple: true
+
+    - name: List the wheels
+      run: |
+        ls -1 dist/
+
+    - name: Rename OSX wheels
+      working-directory: ./dist
+      run: ../bin/rename-wheels # .. because we are starting in ./dist
+
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        verbose: true

--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ a simple file-IO pipeline;
   3. KLR reads kernel.json
   4. KLR writes klr.json
   5. Python reads klr.json into a data structure
+
+
+# Steps to make a new version/wheel
+
+1. Bump the build or minor version in interop/pyproject.toml
+2. Create a git tag of the form v1.2.3 and push it to KLR repo
+
+This should trigger a build that uploads the artifacts to pypi.

--- a/bin/rename-wheels
+++ b/bin/rename-wheels
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e -u -o pipefail
+trap "kill 0" SIGINT SIGTERM
+
+# Used to rename wheels before uploading wheels to pypi
+
+# pypi can't handle the 99.0 version tags. We need to move those back to versions it is OK with
+# While sketchy in the extreme, this should hopefully work. Why?
+# - The step that fails without the 99.0 bump is 'delocate' which looks for libs
+#   linked in at different versions.
+# - Lean/Lake don't have external dependencies besides system libs
+#   https://leanprover.zulipchat.com/#narrow/channel/424609-lean-at-aws/topic/.E2.9C.94.20Build.20static.20binary
+#   I think this is likely a Lean/Lake bug: https://github.com/leanprover/lean4/pull/6631/files
+# - We are setting the version back to the OS that it was compiled on.
+# - Counterpoint to things being OK: if it's true that there are only system libraries, then
+#   `delocate-wheel` shouldn't do anything, but then it's not clear why it's complaining
+#   about the 99.0 min version of Lean.
+
+
+# Example output of ls -1:
+# klr-0.0.3-cp310-cp310-macosx_99_0_arm64.whl
+# klr-0.0.3-cp310-cp310-macosx_99_0_x86_64.whl
+# klr-0.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+# klr-0.0.3-cp311-cp311-macosx_99_0_arm64.whl
+# klr-0.0.3-cp311-cp311-macosx_99_0_x86_64.whl
+# klr-0.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+# klr-0.0.3-cp312-cp312-macosx_99_0_arm64.whl
+# klr-0.0.3-cp312-cp312-macosx_99_0_x86_64.whl
+# klr-0.0.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+# klr-0.0.3-cp313-cp313-macosx_99_0_arm64.whl
+# klr-0.0.3-cp313-cp313-macosx_99_0_x86_64.whl
+# klr-0.0.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+# klr-0.0.3-cp38-cp38-macosx_99_0_arm64.whl
+# klr-0.0.3-cp38-cp38-macosx_99_0_x86_64.whl
+# klr-0.0.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+# klr-0.0.3-cp39-cp39-macosx_99_0_arm64.whl
+# klr-0.0.3-cp39-cp39-macosx_99_0_x86_64.whl
+# klr-0.0.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+
+x86_suffix=macosx_99_0_x86_64
+arm_suffix=macosx_99_0_arm64
+for file in *; do
+  if [[ "$file" == *"$x86_suffix"* ]]; then
+    newname=$(echo "$file" | sed "s/$x86_suffix/macosx_13_0_x86_64/g")
+    mv $file $newname
+    echo "Renamed: $file -> $newname"
+  fi
+  if [[ "$file" == *"$arm_suffix"* ]]; then
+    newname=$(echo "$file" | sed "s/$arm_suffix/macosx_14_0_arm64/g")
+    mv $file $newname
+    echo "Renamed: $file -> $newname"
+  fi
+done

--- a/interop/pyproject.toml
+++ b/interop/pyproject.toml
@@ -5,8 +5,8 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "klr"
-version = "0.0.3"
+name = "klr-lang"
+version = "0.0.6"
 authors = [
   {name = "Paul Govereau", email = "govereau@amazon.com"},
   {name = "Sean McLaughlin", email = "seanmcl@amazon.com"},


### PR DESCRIPTION
Publishes to both test.pypi.org and pypi.org on tag pushes.

Example artifacts: https://test.pypi.org/project/klr/0.0.3/#files
