### PR TITLE
feat: track tensor allocations during tracing

### DIFF
--- a/KLR.lean
+++ b/KLR.lean
@@ -5,3 +5,4 @@ Authors: Paul Govereau, Sean McLaughlin
 -/
 import KLR.Core
 import KLR.Python
+import KLR.Trace

--- a/KLR/Core.lean
+++ b/KLR/Core.lean
@@ -4,4 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul Govereau, Sean McLaughlin
 -/
 import KLR.Core.Basic
-import KLR.Core.Encode
+-- TODO: fix encoder
+--import KLR.Core.Encode
+import KLR.Core.FromToJson
+import KLR.Core.Pretty

--- a/KLR/Core/Basic.lean
+++ b/KLR/Core/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul Govereau, Sean McLaughlin
 -/
-import Lean
 
 /-!
 # Abstract syntax of Core NKL language
@@ -11,31 +10,73 @@ import Lean
 This language is the result of "tracing", and is used as the
 portable format, a.k.a. Kernel Language Representation (KLR).
 -/
-
 namespace KLR.Core
 
--- TODO switch to TensorLib's version of these types
---export TensorLib (Tensor Dtype Shape)
+-- Compute Engines
 
-abbrev Dtype := String
-abbrev Shape := List Int
+inductive Engine where
+  | unassigned
+  | pool
+  | act
+  | pe
+  | dma
+  | dve
+  | sp
+  deriving BEq, Repr
+
+-- ALU operations
+-- TODO organize these into groups
+inductive AluOp where
+  | abs
+  | add
+  | arith_shift_left
+  | arith_shift_right
+  | average
+  | bitwise_and
+  | bitwise_not
+  | bitwise_or
+  | bitwise_xor
+  | bypass
+  | divide
+  | elemwise_mul
+  | is_equal
+  | is_ge
+  | is_gt
+  | is_le
+  | is_lt
+  | logical_and
+  | logical_or
+  | logical_shift_left
+  | logical_shift_right
+  | logical_xor
+  | max
+  | min
+  | mod
+  | mult
+  | not_equal
+  | pow
+  | rsqrt
+  | subtract
+  deriving BEq, Repr
 
 /-
-A TensorName is essentially a typed variable, where the type
-must be a tensor type. When we flush out Typ below we may replace
-this with `Expr.var name (Typ.tensor dtype shape)`. For now, this
-only refers to dynamic tensors, or compile-time tensors, not
-trace-time tensors.
+A TensorName is essentially a typed variable, where the type must be a
+tensor type. This only refers to dynamic tensors, or compile-time
+tensors, not trace-time tensors.
 -/
+abbrev Dtype := String
+abbrev Shape := List Nat
+
+inductive Memory where
+  | dram | sbuf | pmem | reg
+  deriving Repr, BEq
 
 structure TensorName where
   name  : String
   dtype : Dtype
   shape : Shape
-  deriving Repr, BEq, Lean.ToJson
-
--- TODO
-inductive Typ where
+  memory: Memory
+  deriving Repr, BEq
 
 inductive Const where
   | none
@@ -43,7 +84,7 @@ inductive Const where
   | int (value : Int)
   | float (value : Float)
   | string (value : String)
-  deriving Repr, BEq, Lean.ToJson
+  deriving Repr, BEq
 
 -- This corresponds to the "Quasi-Affine Expressions" in Neuron.
 -- Note, `floor` is the usual integer division.
@@ -56,27 +97,72 @@ inductive IndexExpr where
   | floor (expr : IndexExpr) (scalar : Int)
   | ceil (expr : IndexExpr) (scalar : Int)
   | mod (expr : IndexExpr) (scalar : Int)
-  deriving Repr, BEq, Lean.ToJson
+  deriving Repr, BEq
 
 -- Note: `np.newindex` is represented as `(.coord none)`
 inductive Index where
   | ellipsis
   | coord (e : Option IndexExpr)
   | slice (l u step : Option IndexExpr)
-  deriving Repr, BEq, Lean.ToJson
+  deriving Repr, BEq
+
+structure TensorScalar where
+  op0 : AluOp
+  const0 : Float
+  reverse0 : Bool
+  op1 : AluOp
+  const1 : Float
+  reverse1 : Bool
+  deriving Repr, BEq
+
+inductive Operator where
+  | tensorScalar : TensorScalar -> Operator
+  deriving Repr, BEq
 
 inductive Expr where
   | var (x : String)
   | const (c : Const)
   | tensor (t : TensorName)
   | access (t : Expr) (ix : List Index)
+  | operator (op : Operator)
   | call (f : Expr) (args : List Expr) (kwargs : List (String × Expr))
-  deriving Repr, BEq, Lean.ToJson
+  deriving Repr, BEq
 
 inductive Stmt where
-  | pass
-  | expr (v : Expr)
   | ret (v : Expr)
+  | store (t : TensorName) (ix : List Index) (e : Expr)
   | assign (x : String) (e : Expr)
   | loop (x : String) (l u step : IndexExpr) (body : List Stmt)
-  deriving Repr, BEq, Lean.ToJson
+  deriving Repr, BEq
+
+structure Kernel where
+  name : String
+  inputs : List TensorName
+  outputs : List TensorName
+  body : List Stmt
+  deriving Repr, BEq
+
+-- TODO: not efficient
+partial def Expr.tensors : Expr -> List TensorName :=
+  tensors []
+where
+  tensors (l : List TensorName) : Expr -> List TensorName
+  | .var _ => l
+  | .const _ => l
+  | .tensor t => l.insert t
+  | .access t _ => tensors l t
+  | .operator _ => l
+  | .call f args kwargs =>
+      let l := tensors l f
+      let l := args.foldl tensors l
+      kwargs.foldl (fun l kw => tensors l kw.snd) l
+
+partial def Stmt.tensors : Stmt -> List TensorName
+  | .ret e => e.tensors
+  | .store t _ e => e.tensors.insert t
+  | .assign _ e => e.tensors
+  | .loop _ _ _ _ body => (body.map tensors).flatten.eraseDups
+
+def Kernel.internal (k : Kernel) : List TensorName :=
+  let ts := (k.body.map Stmt.tensors).flatten.eraseDups
+  (ts.removeAll k.inputs).removeAll k.outputs

--- a/KLR/Core/FromToJson.lean
+++ b/KLR/Core/FromToJson.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+import Lean
+import KLR.Core.Basic
+
+/-
+# Instances of ToJson for KLR
+
+The instances are placed here, in a separate module, because we need to
+manually write/replace some of the instances, and this may interfere with other
+code.
+-/
+
+namespace KLR.Core
+open Lean (FromJson ToJson)
+
+/-
+The tools we are interacting use a different encoding of infinity and NaN from
+the default instance in Lean.
+-/
+
+instance : ToJson Float where
+  toJson f :=
+    match Lean.JsonNumber.fromFloat? f with
+    | .inr n => .num n
+    | .inl "NaN" => .str "nan"
+    | .inl "Infinity" => .str "inf"
+    | .inl "-Infinity" => .str "-inf"
+    | _ => panic "internal error"
+
+instance : FromJson Float where
+  fromJson?
+    | .str "inf" => return (1.0 / 0.0)
+    | .str "-inf" => return (-1.0 / 0.0)
+    | .str "nan" => return (0.0 / 0.0)
+    | .num jn => return jn.toFloat
+    | _ => throw "Expected a number or 'inf, '-inf, 'nan."
+
+instance : ToJson Engine where
+  toJson
+  | .unassigned => .str "Unassigned"
+  | .pool => .str "Pool"
+  | .act => .str "Activation"
+  | .pe => .str "PE"
+  | .dma => .str "DMA"
+  | .dve => .str "DVE"
+  | .sp => .str "SP"
+
+instance : FromJson Engine where
+  fromJson?
+  | .str "Unassigned" => return .unassigned
+  | .str "Pool" => return .pool
+  | .str "Activation" => return .act
+  | .str "PE" => return .pe
+  | .str "DMA" => return .dma
+  | .str "DVE" => return .dve
+  | .str "SP" => return .sp
+  | .str s => throw s!"unknown engine type {s}"
+  | _ => throw "expecting engine type"
+
+deriving instance ToJson for AluOp
+deriving instance ToJson for Memory
+deriving instance ToJson for TensorName
+deriving instance ToJson for Const
+deriving instance ToJson for IndexExpr
+deriving instance ToJson for Index
+
+deriving instance FromJson for AluOp
+deriving instance FromJson for Memory
+deriving instance FromJson for TensorName
+deriving instance FromJson for Const
+deriving instance FromJson for IndexExpr
+deriving instance FromJson for Index
+
+deriving instance ToJson for TensorScalar
+deriving instance ToJson for Operator
+deriving instance ToJson for Expr
+deriving instance ToJson for Stmt
+deriving instance ToJson for Kernel
+
+deriving instance FromJson for TensorScalar
+deriving instance FromJson for Operator
+deriving instance FromJson for Expr
+deriving instance FromJson for Stmt
+deriving instance FromJson for Kernel

--- a/KLR/Python.lean
+++ b/KLR/Python.lean
@@ -189,6 +189,7 @@ structure Kernel where
   args : List Expr'
   kwargs : List (String × Expr')
   globals : List (String × Expr')
+  deriving Repr
 
 /-
 POC: try to guess suitable arguments if none suplied (see bin/gather).

--- a/KLR/Trace.lean
+++ b/KLR/Trace.lean
@@ -10,11 +10,11 @@ import KLR.Trace.Basic
 import KLR.Trace.Builtin
 import KLR.Trace.Python
 import KLR.Trace.NKI
+import KLR.Trace.Numpy
 
 namespace KLR.Trace
 
-def runNKIKernel (k : KLR.Python.Kernel) : Err (List KLR.Core.Stmt) :=
-  tracer ⟨ .ofList NKIEnv, #[] ⟩ do
-    traceKernel k
-    let g <- get
-    return g.body.toList
+def globalEnv := NKIEnv ++ NumpyEnv
+
+def runNKIKernel (k : KLR.Python.Kernel) : Err KLR.Core.Kernel :=
+  tracer ⟨ .ofList globalEnv, #[] ⟩ (traceKernel k)

--- a/KLR/Trace/Basic.lean
+++ b/KLR/Trace/Basic.lean
@@ -73,6 +73,7 @@ def Term.isTrue : Term -> Err Bool
   | .list _   => return true
   | .ellipsis => return true
   | .slice _ _ _ => return true
+  | .store _ _ _ => return true
   | .expr (.const c) _ => return c.isTrue
   | .expr _ _ => throw "non-constant expression"
 
@@ -264,7 +265,7 @@ def Term.attr : Term -> String -> TraceM Term
   | t, id => throw s!"unsupported attribute {id} on {repr t}"
 where
   str s  := .expr (.const $ .string s) .string
-  list l := .list $ l.map fun i => .expr (.const (.int i)) .int
+  list l := .list $ l.map fun i => .expr (.const (.int $ .ofNat i)) .int
 
 def Item.attr : Item -> String -> Tracer Item
   | .module n, id => lookup_global (n.str id)
@@ -281,4 +282,5 @@ def Term.call (f : Term)
   | .list _      => throw "list is not a callable type"
   | .ellipsis    => throw "ellipsis is not a callable type"
   | .slice _ _ _ => throw "slice is not a callable type"
+  | .store _ _ _ => throw "tensor is not a callable type"
   | .expr f _    => return .expr (.call f args kws) (.obj "object".toName)

--- a/KLR/Trace/NKI.lean
+++ b/KLR/Trace/NKI.lean
@@ -6,6 +6,7 @@ Authors: Paul Govereau, Sean McLaughlin
 import KLR.Core
 import KLR.Trace.Types
 import KLR.Trace.Builtin
+import KLR.Trace.Tensor
 
 /-
 # NKI built-ins
@@ -14,6 +15,7 @@ This module defines the builtin constants used by tracing for NKI kernels.
 -/
 namespace KLR.Trace
 open KLR.Core
+open KLR.Trace.Builtin
 
 private def nki : Name := .str .anonymous "nki"
 private def nki_isa : Name := .str nki "isa"
@@ -21,15 +23,6 @@ private def nki_lang : Name := .str nki "language"
 
 private def nl : String -> Name := .str nki_lang
 private def nisa : String -> Name := .str nki_isa
-
-private def module (name : Name) : Name × Item :=
-  (name, .module name)
-
-private def const_var (name: Name) : Name × Item :=
-  (name, .term (.expr (.var name.toString) (.obj name)))
-
-private def global (g : Global) : Name × Item :=
-  (g.name, .global g)
 
 /-
 Note: this object contains a bunch of architecture parameters that
@@ -94,9 +87,12 @@ def NKIEnv : List (Name × Item) :=
   , module nki_isa
   , module nki_lang
   , const_var (nl "add")
-  , const_var (nl "load")
-  , const_var (nl "store")
   , const_var (nl "exp")
+  , const_var (nl "shared_hbm")
   , global tile_size
   , global arange
+  , globalFn (nl "ndarray") Tensor.ndarray
+  , globalFn (nl "load") Tensor.load
+  , globalFn (nl "store") Tensor.store
+  , globalFn (nisa "tensor_scalar") Tensor.tensor_scalar
   ]

--- a/KLR/Trace/Numpy.lean
+++ b/KLR/Trace/Numpy.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+import KLR.Core
+import KLR.Trace.Types
+import KLR.Trace.Builtin
+
+/-
+# Numpy built-ins
+-/
+namespace KLR.Trace
+open KLR.Trace.Builtin
+
+private def numpy : Name := .str .anonymous "numpy"
+private def np : String -> Name := .str numpy
+
+def NumpyEnv : List (Name × Item) :=
+  [ module numpy
+  , const_var (np "add")
+  , const_var (np "subtract")
+  , const_var (np "multiply")
+  ]

--- a/KLR/Trace/Tensor.lean
+++ b/KLR/Trace/Tensor.lean
@@ -5,6 +5,7 @@ Authors: Paul Govereau, Sean McLaughlin
 -/
 import KLR.Core
 import KLR.Trace.Types
+import KLR.Trace.Builtin
 
 /-
 # Tracing for Tensor related operations
@@ -13,6 +14,219 @@ TODO: These are just place holders...
 -/
 namespace KLR.Trace
 open KLR.Core
+open KLR.Trace.Builtin
+
+namespace Tensor
+
+-- decompose a tensor expresssion
+def Expr.inferTensor : Expr -> Err (TensorName × List Index)
+  | .tensor t => return (t, [.ellipsis])
+  | .access t ix => do
+      match <- inferTensor t with
+      | (t, [.ellipsis]) => return (t, ix)
+      | _ => throw "unsupported tensor expression"
+  | _ => throw "expecting tensor"
+
+def Term.inferTensor : Term -> Err (TensorName × List Index)
+  | .expr e (.tensor _ _) => Expr.inferTensor e
+  | _ => throw "expecting tensor"
+
+-- This only handles the simple cases
+-- Note: Maybe only simple cases are possible at this point ??
+def inferShape (t : TensorName) : List Index -> Err Shape
+  | [] | [.ellipsis] => return t.shape
+  | ix => do
+      let base := t.shape
+      if base.length != ix.length then
+        throw "unsupported index"
+      let dims <- (base.zip ix).mapM fun (x, i) =>
+        match i with
+        | .coord _ => return 0
+        | .slice none none none
+        | .slice (some (.int 0)) none none => return x
+        | .slice none (some (.int i)) none
+        | .slice (some (.int 0)) (some (.int i)) none => return i.toNat
+        | _ => throw "unsupported index"
+      return dims.filter (. != 0)
+
+def Expr.inferShape (e : Expr) : Err Shape := do
+  let (t, ix) <- inferTensor e
+  Tensor.inferShape t ix
+
+/-
+Declare a new tensor, unique to the current expression.
+
+We have to calculate how much memory we are going to use. The most memory we
+could need is one tensor for each expression in the source program (loops can
+reuse the same memory in each iteration). This code gives the name of the
+tensor associated with an expression. Right now I am using the source location,
+but we could also use a hash of expression, or something else. Note, this
+expression may be evaluated many times, and we want this function to always
+return the same result.
+
+In the end we walk over the KLR kernel and collect all the TensorNames, and
+these represent the memory we need to allocate in the dram, sbuf, etc.
+-/
+def declare (tag : String)
+            (dtype : Dtype) (shape : Shape) (memory : Memory)
+            : TraceM TensorName := do
+  let pos := (<- get).pos
+  let tname := s!"{tag}.{pos.lineno}.{pos.col_offset}"
+  return {
+    name := tname
+    dtype := dtype
+    shape := shape
+    memory := memory
+    }
+
+-- generate a store expression based on the src shape
+def store_expr (tag : String)
+               (dtype : Dtype) (memory : Memory) (src : Term)
+               : TraceM Term := do
+  match src with
+  | .expr e (.tensor _ shape) => do
+      let dst <- declare tag dtype shape memory
+      return .store dst [.ellipsis] e
+  | _ => throw "expecting tensor"
+
+-- APIs
+
+-- conversion to NKI
+
+private def some_none : Option Term :=
+  some (.expr (.const .none) .none)
+
+private def some_bool (b : Bool) : Option Term :=
+  some (.expr (.const (.bool b)) .bool)
+
+private def some_int (i : Int) : Option Term :=
+  some (.expr (.const (.int i)) .int)
+
+private def some_string (s : String) : Option Term :=
+  some (.expr (.const (.string s)) .string)
+
+-- conversion from NKI
+
+def Option.fromNKI (f : Term -> Err a) (dflt : a) : Term -> Err a
+  | .expr (.const .none) .none => return dflt
+  | e => f e
+
+def Bool.fromNKI : Term -> Err Bool
+ | .expr (.const (.bool b)) .bool => return b
+ | _ => throw "expecting boolean"
+
+def Int.fromNKI : Term -> Err Int
+ | .expr (.const (.int i)) .int => return i
+ | _ => throw "expecting integer"
+
+def Nat.fromNKI (t : Term) : Err Nat :=
+  return (<- Int.fromNKI t).toNat
+
+def Float.fromNKI : Term -> Err Float
+ | .expr (.const (.float f)) .float => return f
+ | _ => throw "expecting float"
+
+def String.fromNKI : Term -> Err String
+  | .expr (.const (.string s)) .string => return s
+  | _ => throw "expecting string"
+
+def Memory.fromNKI (t : Term) : Err Memory :=
+  match t.type with
+  | .obj name =>
+    match name.toString with
+    | "nki.language.shared_hbm" => return .dram
+    | "nki.language.sbuf" => return .sbuf
+    | "nki.language.pmem" => return .pmem
+    | _ => throw "expecting buffer type"
+  | _ => throw "expecting buffer type"
+
+def Shape.fromNKI : Term -> Err Shape
+  | .list l | .tuple l => l.mapM Nat.fromNKI
+  | _ => throw "expecting shape"
+
+def AluOp.fromNKI : Term -> Err AluOp
+  | .expr (.var name) _ =>
+      match name with
+      | "numpy.subtract" => return .subtract
+      | name => throw s!"unsupported operator {name}"
+  | t => throw s!"expecting operator got {repr t}"
+
+/-
+TODO: These definitions are very verbose, but this pattern could be made more
+convenient with a typeclass (fromNKI) and a command macro, maybe something
+like:
+
+#nki ndarray(shape:Shape, dtype:Dtype, memory:Memory = .sbuf) := do
+  let t <- declare "t" dtype shape memory
+  ...
+-/
+def ndarray : GlobalFn :=
+  withArgs [("shape", none),
+            ("dtype", none),
+            ("buffer", some_string "nki.language.sbuf")]
+  fun
+  | [shape, dtype, buf] => do
+      let shape <- Shape.fromNKI shape
+      let dtype <- String.fromNKI dtype
+      let memory <- Memory.fromNKI buf
+      let t <- declare "ndarray" dtype shape memory
+      return .expr (.tensor t) (.tensor dtype shape)
+  | _ => throw "invalid arguments"
+
+def load : GlobalFn :=
+  withArgs [("src", none),
+            ("mask", some_none),
+            ("dtype", some_string "float32")]
+  fun
+  | [t, _, dtype] => do
+      let dtype <- String.fromNKI dtype
+      store_expr "load" dtype .sbuf t
+  | _ => throw "invalid arguments"
+
+def store : GlobalFn :=
+  withArgs [("dst", none),("value", none)]
+  fun
+  | [.expr dst (.tensor _ s₁), .expr src (.tensor _ s₂)] => do
+      if s₁ != s₂ then
+        throw "incompatible shapes {s₁} {s₂}"
+      let (t₁, i₁) <- Expr.inferTensor dst
+      let (t₂, i₂) <- Expr.inferTensor src
+      let src := Expr.access (.tensor t₂) i₂
+      return Term.store t₁ i₁ src
+  | _ => throw "invalid arguments"
+
+def tensor_scalar : GlobalFn :=
+  withArgs [("data", none),
+            ("op0", none),
+            ("operand0",none),
+            ("reverse0", some_bool false),
+            ("op1", some_none),
+            ("operand1", some_none),
+            ("reverse1", some_bool false),
+            ("dtype", some_none)]
+  fun
+  | [data, op0, operand0, reverse0, op1, operand1, reverse1, dtype] => do
+      let (t, ix) <- Term.inferTensor data
+      let shape <- inferShape t ix
+      let dtype <- Option.fromNKI String.fromNKI t.dtype dtype
+      let op : TensorScalar := {
+           op0 := <- AluOp.fromNKI op0
+           const0 := <- Float.fromNKI operand0
+           reverse0 := <- Option.fromNKI Bool.fromNKI false reverse0
+           op1 := <- Option.fromNKI AluOp.fromNKI .bypass op1
+           const1 := <- Option.fromNKI Float.fromNKI 0.0 operand1
+           reverse1 := <- Option.fromNKI Bool.fromNKI false reverse1
+           }
+      let e := Expr.operator (.tensorScalar op)
+      let ty := TermType.tensor dtype shape
+      let e := Expr.call e [.access (.tensor t) ix] []
+      store_expr "tsc" dtype .sbuf (.expr e ty)
+  | _ => throw "invalid arguments"
+
+end Tensor
+
+--------
+-- TODO: These are just placeholdrs for the python operators
 
 private def tensor_call (op : String) (args : List Expr) : Term :=
   let type := if let .tensor t :: _ := args
@@ -34,7 +248,7 @@ def tensor_tensor (op : BinOp) (l r : TensorName) : TraceM Term :=
   return tensor_call op [.tensor l, .tensor r]
 
 private def broadcast (t : TensorName) (c : Const) : Expr :=
-  let args := t.shape.map fun i => Expr.const (.int i)
+  let args := t.shape.map fun i => Expr.const (.int $ .ofNat i)
   let args := .const c :: args
   .call (.var "broadcast") args []
 

--- a/Main.lean
+++ b/Main.lean
@@ -1,22 +1,33 @@
 import KLR
 import Cli
-import KLR.Python
-import KLR.Trace
 open Cli
-
 
 local instance : MonadLift Err IO where
   monadLift
     | .ok x => return x
     | .error s => throw $ .userError s
 
-def parseJson (p : Parsed) : IO UInt32 := do
+private def parse (p : Parsed) : IO KLR.Python.Kernel := do
   let file := p.positionalArg! "file" |>.as! String
   let s <- IO.FS.readFile file
-  let kernel <- KLR.Python.Parsing.parse s
-  let stmts <- KLR.Trace.runNKIKernel kernel.inferArguments
-  let json := Lean.Json.arr (stmts.map Lean.toJson).toArray
+  KLR.Python.Parsing.parse s
+
+def parseJson (p : Parsed) : IO UInt32 := do
+  let kernel <- parse p
+  let klr <- KLR.Trace.runNKIKernel kernel.inferArguments
+  let json := Lean.toJson klr
   IO.println json
+  return 0
+
+def trace (p : Parsed) : IO UInt32 := do
+  let kernel <- parse p
+  let klr <- KLR.Trace.runNKIKernel kernel.inferArguments
+  if p.hasFlag "repr" then
+    IO.println (toString $ repr klr)
+  else if p.hasFlag "json" then
+    IO.println (toString $ Lean.toJson klr)
+  else
+    IO.println (Lean.format klr).pretty
   return 0
 
 def parseJsonCmd := `[Cli|
@@ -27,12 +38,24 @@ def parseJsonCmd := `[Cli|
     file : String;      "File of Python AST printed as JSON"
 ]
 
+def traceCmd := `[Cli|
+  "trace" VIA trace;
+  "Trace Python to KLR"
+
+  FLAGS:
+    r, repr; "Output Repr format"
+    j, json; "Output Json format"
+  ARGS:
+    file : String; "File of Python AST printed as JSON"
+]
+
 def klrCmd : Cmd := `[Cli|
   klr NOOP; ["0.0.1"]
   "KLR is an IR for NKI and other tensor-like languages in Lean."
 
   SUBCOMMANDS:
-    parseJsonCmd
+    parseJsonCmd;
+    traceCmd
 ]
 
 def main (args : List String) : IO UInt32 :=
@@ -40,4 +63,4 @@ def main (args : List String) : IO UInt32 :=
     IO.println klrCmd.help
     return 0
   else do
-   klrCmd.validate args
+    klrCmd.validate args


### PR DESCRIPTION
This patch adds the ability to track needed tensor allocations during the tracing process. To do this, a new `store` statement and term expression are added.  A more complete implementation of the tensor_scalar operator is included as a test case for the new mechanism.