### PR TITLE
ci: Add arm build host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
         # macos-13 is x86
         # macos-latest is arm64
         # ubuntu-latest is x64
-        os: [ubuntu-latest, macos-latest, macos-13]
+        # ubuntu-latest is x64
+        os: [ubuntu-latest, ubuntu-24.04-arm, ubumacos-latest, macos-13]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
We currently aren't building ARM wheels. I'm not sure this will work, but let's try it. We only push the wheels on the main branch, so we need to merge this to try it.

Build works:
https://github.com/leanprover/KLR/actions/runs/13293628967/job/37120447588