### PR TITLE
feat: Detect undefined symbols

### DIFF
--- a/bin/gather
+++ b/bin/gather
@@ -21,10 +21,12 @@ if len(sys.argv) != 2:
   print(f"Usage: {sys.argv[0]} function", file=sys.stderr)
   sys.exit(1)
 
-pieces = sys.argv[1].split(".")
+[bin, kernel] = sys.argv
+
+pieces = kernel.split(".")
 if len(pieces) < 2:
   print("Please, specify full path name of function, e.g.:", file=sys.stderr)
-  print(f"  {sys.argv[0]} mylib.mykernel", sys.argv[0], file=sys.stderr)
+  print(f"  {bin} mylib.mykernel", file=sys.stderr)
   sys.exit(1)
 
 try:
@@ -33,8 +35,7 @@ try:
   m = importlib.import_module(module)
   f = getattr(m, fn)
   F = klr.parser.Parser(f)
+  print(F.json())
 except Exception as e:
   print(str(e), file=sys.stderr)
   sys.exit(1)
-
-print(F.json())

--- a/interop/test/test_basic.py
+++ b/interop/test/test_basic.py
@@ -125,7 +125,7 @@ def test_succeed(f):
 # (These functions are expected to fail elaboration to KLR)
 
 def name_not_found():
-  return x
+  x
 
 @pytest.mark.parametrize("f", [
   name_not_found,


### PR DESCRIPTION
Our current Python parser does not notice undefined symbols. While we don't do anything with them now, we want to pass that info back to the caller in the forthcoming linter. In addition, we intended parsing to fail when there are undefined symbols, as indicated in test_basic.py, but it was failing for an unrelated reason before, and broke a few commits ago.

This change just makes a best effort attempt to notice undefined symbols, and crashes accordingly in the klr binary. In the future we will do more with this.

This change fixes the broken CI build.