### PR TITLE
feat: Scripts to generate and run BIR

### DIFF
--- a/KLR/Util.lean
+++ b/KLR/Util.lean
@@ -45,3 +45,5 @@ Note: ▷ is typed as \rhd
 -/
 notation f "▷" l =>
   List.mapM (fun ⟨ x, _ ⟩ => f x) (List.attach l)
+
+def impossible {a : Type} [h : Inhabited a] (msg : String := "") := @panic a h s!"Invariant violation: {msg}"

--- a/Main.lean
+++ b/Main.lean
@@ -1,5 +1,9 @@
 import KLR
+import KLR.BIR.Compile
 import Cli
+import KLR.Util
+
+open KLR
 open Cli
 
 local instance : MonadLift Err IO where
@@ -7,25 +11,115 @@ local instance : MonadLift Err IO where
     | .ok x => return x
     | .error s => throw $ .userError s
 
-def gather (p : Parsed) : IO UInt32 := do
-  let kernel := p.positionalArg! "kernel" |>.as! String
-  let path1 <- IO.appPath
-  let path2 := (<- IO.currentDir).join "bin"
-  for p in [path1, path2] do
-    let exe := (p.join "gather")
+def showAs [Lean.ToJson a] [Repr a] (p : Parsed) (x : a) : IO Unit :=
+  if p.hasFlag "repr" then
+    IO.println (toString $ repr x)
+  else if p.hasFlag "json" then
+    IO.println (toString $ Lean.toJson x)
+  else
+    -- For now, default is JSON, but we may change this
+    IO.println (toString $ Lean.toJson x)
+
+def eprintln [ToString a] (debug : Bool) (x : a) : IO Unit := do
+  if debug then IO.eprintln x
+
+/-
+We have a mix of Python and Lean executables, so need to worry about
+PYTHONPATH. In the Bash/Python gather exe below, we expect input of the
+form
+
+    # bin/gather my_kernel_module.my_kernel_function
+
+It is natural to expect being able to pass a file name here, but that
+doesn't work; we expect the module's file to be on PYTHONPATH.
+
+From Lean, we will take a filename and a kernel name, and muck with
+the PYTHONPATH accordingly.
+-/
+structure FileNameParts where
+  private mk::
+  dirs : List String
+  fileNameNoExt : String
+  ext : Option String
+  deriving BEq, Inhabited, Repr
+
+namespace FileNameParts
+
+def fileName (parts : FileNameParts) : String := match parts.ext with
+| none => parts.fileNameNoExt
+| some ext => parts.fileNameNoExt ++ "." ++ ext
+
+def make (file : String) : FileNameParts :=
+  let (dirs, file) := match (file.splitOn "/").reverse with
+  | [] => impossible
+  | [f] => ([], f)
+  | f :: dirs => (dirs.reverse, f)
+  let (file, ext) := match (file.splitOn ".").reverse with
+  | [] => impossible
+  | [f] => (f, none)
+  | ext :: fs => (String.intercalate "." fs.reverse, some ext)
+  FileNameParts.mk dirs file ext
+
+def dir (parts : FileNameParts) : String := String.intercalate "/" parts.dirs
+
+def pathToFile (parts : FileNameParts) : String :=
+  String.intercalate "." (parts.dirs ++ [parts.fileNameNoExt] ++ parts.ext.toList)
+
+#guard FileNameParts.make "foo" == FileNameParts.mk [] "foo" none
+#guard FileNameParts.make "foo/bar" == FileNameParts.mk ["foo"] "bar" none
+#guard FileNameParts.make "a/b/c.bar" == FileNameParts.mk ["a", "b"] "c" (some "bar")
+#guard (FileNameParts.make "a.b.c.bar").pathToFile == "a.b.c.bar"
+#guard (FileNameParts.make "a/b/c.bar").dir == "a/b"
+
+end FileNameParts
+
+def gatherStr (moduleFileName kernelFunctionName : String) (klrPythonModuleDir : Option String) (debug : Bool) : IO String := do
+  let dbg := eprintln debug
+  let pypath <- IO.getEnv "PYTHONPATH"
+  let pypath := pypath.getD ""
+  let parts := FileNameParts.make moduleFileName
+  dbg $ "parts: " ++ repr parts
+  let gather1 := (<- IO.appPath).parent.get!.join "gather"
+  let gather2 := (<- IO.currentDir).join "bin/gather"
+  -- The directory of the kernel file must be on PYTHONPATH
+  let pypath := match parts.dirs with
+  | [] => pypath
+  | _ => pypath ++ ":" ++ parts.dir
+  -- The klr directory must also be there. A better implementation would check to see if it's on
+  -- the path already without adding `interop`
+  let klrDir := klrPythonModuleDir.getD "interop" -- interop is the project default
+  let pypath := pypath ++ ":" ++ klrDir
+  let gatherArg := parts.fileNameNoExt ++ "." ++ kernelFunctionName
+  for exe in [gather1, gather2] do
+    dbg $ "exe: " ++ exe.toString
+    dbg $ "pypath: " ++ pypath
     if <- exe.pathExists then
-      try do
-        let output <- IO.Process.run {
-          cmd := exe.toString
-          args := #[ kernel ]
-        }
-        IO.println output
-        return 0
-      catch _ =>
-        IO.println s!"gather failed: please make sure {kernel} is in your PYTHONPATH"
-        return 1
-  IO.println s!"could not find gather program"
-  return 2
+      let output <- IO.Process.output {
+        cmd := exe.toString
+        args := #[ gatherArg ]
+        env := #[ ("PYTHONPATH", some pypath) ]
+      }
+      dbg $ "stdout: " ++ output.stdout
+      dbg $ "stderr: " ++ output.stderr
+      return output.stdout
+  IO.throwServerError "could not find gather program"
+
+def gather (p : Parsed) : IO UInt32 := do
+  let debug := p.hasFlag "debug"
+  let file := p.positionalArg! "moduleFileName" |>.as! String
+  let kernel := p.positionalArg! "kernelFunctionName" |>.as! String
+  let dir := (p.flag? "klr-module-dir").map fun x => x.as! String
+  try
+    let output <- gatherStr file kernel dir debug
+    IO.println output
+    return 0
+  catch
+  | IO.Error.userError s =>
+    IO.println s
+    return 1
+  | err =>
+    IO.println err
+    return 1
 
 private def parse (p : Parsed) : IO KLR.Python.Kernel := do
   let file := p.positionalArg! "file" |>.as! String
@@ -42,12 +136,7 @@ def parseJson (p : Parsed) : IO UInt32 := do
 def trace (p : Parsed) : IO UInt32 := do
   let kernel <- parse p
   let klr <- KLR.Trace.runNKIKernel kernel.inferArguments
-  if p.hasFlag "repr" then
-    IO.println (toString $ repr klr)
-  else if p.hasFlag "json" then
-    IO.println (toString $ Lean.toJson klr)
-  else
-    IO.println (Lean.format klr).pretty
+  showAs p klr
   return 0
 
 def parseBIR (p : Parsed) : IO UInt32 := do
@@ -55,32 +144,44 @@ def parseBIR (p : Parsed) : IO UInt32 := do
   let str <- IO.FS.readFile file
   let json <- Lean.Json.parse str
   let bir : KLR.BIR.BIR <- Lean.fromJson? json
-  if p.hasFlag "repr" then
-    IO.println s!"{repr bir}"
-  else
-    IO.println s!"{Lean.toJson bir}"
+  showAs p bir
   return 0
+
+def compileStr (s : String) : Err KLR.BIR.BIR := do
+  let kernel <- KLR.Python.Parsing.parse s
+  let klr <- KLR.Trace.runNKIKernel kernel.inferArguments
+  KLR.BIR.compile klr
 
 def compile (p : Parsed) : IO UInt32 := do
   let file := p.positionalArg! "file" |>.as! String
   let s <- IO.FS.readFile file
-  let kernel <- KLR.Python.Parsing.parse s
-  let klr <- KLR.Trace.runNKIKernel kernel.inferArguments
-  let bir <- KLR.BIR.compile klr
-  if p.hasFlag "repr" then
-    IO.println (toString $ repr bir)
-  else
-    IO.println (toString $ Lean.toJson bir)
+  let bir <- compileStr s
+  showAs p bir
   return 0
 
--- Command configuration
+def nkiToBIR (p : Parsed) : IO UInt32 := do
+  let debug := p.hasFlag "debug"
+  let file := p.positionalArg! "moduleFileName" |>.as! String
+  let kernel := p.positionalArg! "kernelFunctionName" |>.as! String
+  let dir := (p.flag? "klr-module-dir").map fun x => x.as! String
+  let s <- gatherStr file kernel dir debug
+  let bir <- compileStr s
+  showAs p bir
+  return 0
+
+-- -- Command configuration
 
 def gatherCmd := `[Cli|
   "gather" VIA gather;
   "Gather Python sources into a JSON file"
 
+  FLAGS:
+    d, "klr-module-dir" : String; "Directory of Python klr module. Added to PYTHONPATH."
+    debug : Unit; "Print debugging info"
+
   ARGS:
-    kernel : String; "Full path of kernel function"
+    moduleFileName : String; "File of the Python module with the kernel function"
+    kernelFunctionName : String; "Name of the kernel function"
 ]
 
 def parseJsonCmd := `[Cli|
@@ -122,6 +223,20 @@ def compileCmd := `[Cli|
     file : String; "File of Python AST printed as JSON"
 ]
 
+def nkiToBIRCmd := `[Cli|
+  "nki-to-bir" VIA nkiToBIR;
+  "Compile NKI kernel in Python to BIR"
+
+  FLAGS:
+    d, "klr-module-dir" : String; "Directory of Python klr module. Added to PYTHONPATH."
+    r, repr; "Output Repr format, instead of JSON"
+    debug : Unit; "Print debugging info"
+
+  ARGS:
+    moduleFileName : String; "File of the Python module with the kernel function"
+    kernelFunctionName : String; "Name of the kernel function"
+]
+
 def klrCmd : Cmd := `[Cli|
   klr NOOP; ["0.0.7"]
   "KLR is an IR for NKI and other tensor-like languages in Lean."
@@ -129,6 +244,7 @@ def klrCmd : Cmd := `[Cli|
   SUBCOMMANDS:
     compileCmd;
     gatherCmd;
+    nkiToBIRCmd;
     parseBIRCmd;
     parseJsonCmd;
     traceCmd

--- a/bin/make-wheel
+++ b/bin/make-wheel
@@ -10,7 +10,9 @@ mkdir -p $WHEEL_DIR/{klr,bin}
 lake build
 
 # Get klr binary
-cp .lake/build/bin/klr $WHEEL_DIR/bin/klr
+cp $ROOT/.lake/build/bin/klr $WHEEL_DIR/bin
+# Get gather binary
+cp $ROOT/bin/gather $WHEEL_DIR/bin
 
 # Get Python packages
 cp -R $PYTHON_DIR/* $WHEEL_DIR

--- a/bin/run-bir
+++ b/bin/run-bir
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -e -u -o pipefail
+trap "kill 0" SIGINT SIGTERM
+
+# Run a BIR JSON file on a trn EC2 instance using the public Neuron SDK
+# You can create one, for example, using make-bir in this directory.
+# To use this, copy your BIR.json file to the instance and run this
+# script. You will need several tools from the Neuron SDK in your path.
+# A bunch of files get generated, so it's best to do this in a new
+# directory, where the only file is the BIR. E.g. a workable pattern is
+# something like this, where 'trn' is a profile of a trainium instance
+# in your .ssh/config
+#
+#    osx$ scp run-bir trn:bin/run-bir # assumes bin is a dir at user root on the path
+#    osx$ scp bir.json trn:
+#    osx$ ssh trn
+#    trn$ mkdir bir && mv bir.json bir && cd bir
+#    trn$ run-bir bir.json
+#
+if [[ $# != 1 ]]; then
+  echo "Usage: run-bir BIR_FILE.json"
+  exit 1
+fi
+
+BIR_FILE=$1; shift
+NEFF_FILE=$BIR_FILE.neff
+LOG_FILE=$(mktemp log-neuron-cc.XXX.txt)
+
+# TODO: Absolute path to NCC is sketchy here. Find a better way.
+NEURONXCC_DIR=/opt/aws_neuronx_venv_pytorch_2_5/lib64/python3.9/site-packages/neuronxcc
+#TODO: This gets generated during compilation. Still figuring this out.
+TENSOR_MAP_FILE=tensor_map.json
+
+WALRUS_DRIVER=$NEURONXCC_DIR/starfish/bin/walrus_driver
+echo "Logging to $LOG_FILE"
+# Args are from a regular run of NKI baremetal logs
+$WALRUS_DRIVER \
+  -i $BIR_FILE \
+  --logfile $LOG_FILE \
+  --neff-output-filename $NEFF_FILE \
+  --act-root-json $NEURONXCC_DIR/pwp/pwp_bin_trainium/act_info.json \
+  --dve-root-json $NEURONXCC_DIR/neuronxcc/dve/dve_bin_gen2/dve_info.json \
+  --tensor-map $TENSOR_MAP_FILE \
+  --optlevel 2 \
+  --allocator coloring \
+  --verbose 60 \
+  --logfile-verbose 20 \
+  --execute-repetition 1 \
+  --min_split_size 10240 \
+  --skip_split_vns '' \
+  --no_split_dram \
+  --split_huge_dram_tensor 1.0 \
+  --preprocessing_only \
+  --max_tensorizer_distance 64 \
+  --pack_same_shape_only \
+  --instruction_fetch_latency 511 \
+  --max-partitions 1 \
+  --policy 3 \
+  --auxflag 0 \
+  --interleave none \
+  --schedule-delayed-latency 1 \
+  --postsched-mm-accum-reorder=false \
+  --max-load-lower-bound 0.14 \
+  --force-prefetch-follow-incoming-order -1 \
+  --allreduce-buffer-size 500 \
+  --dram-page-size 512 \
+  --dram-rotation-size -1 \
+  --allreduce-rotation-dis 8 \
+  --repeat-load-thres 4 \
+  --enable-mm-transpose-remat-optimization=true \
+  --save-len-thres 512 \
+  --save-dma-cnt-thres 32 \
+  --relaxed-order=true \
+  --enable-anti-dependence-reduction=false \
+  --num-semaphores-per-queue 16 \
+  --numcores 1 \
+  --unified-backend-and-legacy-codegen \
+  --enable-verifier=true \
+  --enable-birsim=false \
+  --enable-birsim-sync-only=false \
+  --enable-data-race-checker=false \
+  --enable-new-backend=true \
+  --inject-error=NONE \
+  --dge-levels scalar_dynamic_offset,vector_dynamic_offsets \
+  --dynamic-dma-scratch-size-per-partition=16384
+
+# TODO: Run the neff
+# neuron-profile capture -n ...

--- a/interop/MANIFEST.in
+++ b/interop/MANIFEST.in
@@ -1,2 +1,3 @@
 # All files must be below the python project root
 include bin/klr
+include bin/gather


### PR DESCRIPTION
Adds some scripts and cli improvement to run gather and nki-to-bir without requiring explicit PYTHONPATH munging.

The run-bir script has some hard-coded paths at the moment, but
we should be able to get more general, or at least give a
list of instructions for getting the right setup as a followup.

This adds `gather` to the wheel, so we can run from the wheel.
For example

    $ lake build
    $ bin/make-wheel
    $ cd /tmp
    $ virtualenv env
    $ source env/bin/activate
    $ pip install ~/workplace/sherloc/KLR/.wheel/dist/klr_lang-0.0.7-cp313-cp313-macosx_14_0_arm64.whl
    $ env/lib/python3.13/site-packages/bin/klr nki-to-bir ~/workplace/sherloc/KLR/interop/test/test_nki_isa_tensor_scalar.py kernel1
    {"version": 2,
     "functions":
     [{"name": "sg0000",
     ...
