### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @govereau @seanmcl @jtristan

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,0 @@
-* trjohnb@amazon.com
-* govereau@amazon.com
-* seanmcl@amazon.com


### PR DESCRIPTION
The previous CODEOWNER file was in the wrong place, at the root. It is only picked up by github in .github/CODEOWNERS or docs/CODEOWNERS. I didn't realize we had a file bc the repo wasn't showing us as having one. 