### PR TITLE
feat: implement all tensor_scalar ALU ops and types

### DIFF
--- a/KLR/BIR/Compile/Memory.lean
+++ b/KLR/BIR/Compile/Memory.lean
@@ -23,8 +23,8 @@ tensors have the same basic layout.
 -- TODO: just a for instance...
 def physicalShape (t : TensorName) : Shape :=
   match t.dtype, t.shape with
-  | "float16", [x, y] => [x, y * 2]
-  | "float32", [x, y] => [x, y * 4]
+  | .float16, [x, y] => [x, y * 2]
+  | .float32, [x, y] => [x, y * 4]
   | _, _ => t.shape -- TODO incorrect
 
 -- Create memory region corresponding to a named tensor
@@ -84,7 +84,7 @@ def slicesToAP (d1 d2 : Nat) : List Index -> Compile PhysicalAccessPattern
 
 private def setMemRef (t : TensorName) (ap : PhysicalAccessPattern) : PhysicalAccessPattern :=
   { ap with
-    dtype := t.dtype
+    dtype := toString (Std.format t.dtype)
     memsetref := t.name ++ "_set"
     memref := t.name
   }

--- a/KLR/BIR/Function.lean
+++ b/KLR/BIR/Function.lean
@@ -84,7 +84,7 @@ structure MemoryLocation where
 structure Allocation where
   Skind : StorageKind := .memory_location_set
   addr_space : Option AddrSpace
-  dtype : Option String
+  dtype : Option Dtype
   partition_dim : Option Nat
   tensor_shape : List Nat
   name : String

--- a/KLR/Core/Basic.lean
+++ b/KLR/Core/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul Govereau, Sean McLaughlin
 -/
+import KLR.Core.Operators
 
 /-!
 # Abstract syntax of Core NKL language
@@ -12,64 +13,12 @@ portable format, a.k.a. Kernel Language Representation (KLR).
 -/
 namespace KLR.Core
 
--- Compute Engines
-
-inductive Engine where
-  | unassigned
-  | pool
-  | act
-  | pe
-  | dma
-  | dve
-  | sp
-  deriving BEq, Repr
-
--- ALU operations
--- TODO organize these into groups
-inductive AluOp where
-  | abs
-  | add
-  | arith_shift_left
-  | arith_shift_right
-  | average
-  | bitwise_and
-  | bitwise_not
-  | bitwise_or
-  | bitwise_xor
-  | bypass
-  | divide
-  | elemwise_mul
-  | is_equal
-  | is_ge
-  | is_gt
-  | is_le
-  | is_lt
-  | logical_and
-  | logical_or
-  | logical_shift_left
-  | logical_shift_right
-  | logical_xor
-  | max
-  | min
-  | mod
-  | mult
-  | not_equal
-  | pow
-  | rsqrt
-  | subtract
-  deriving BEq, Repr
-
 /-
 A TensorName is essentially a typed variable, where the type must be a tensor
 type. This only refers to dynamic (run-time) tensors, not trace-time tensors.
 -/
 
-abbrev Dtype := String
 abbrev Shape := List Nat
-
-inductive Memory where
-  | dram | sbuf | pmem | reg
-  deriving Repr, BEq
 
 structure TensorName where
   name  : String
@@ -104,19 +53,6 @@ inductive Index where
   | ellipsis
   | coord (e : Option IndexExpr)
   | slice (l u step : Option IndexExpr)
-  deriving Repr, BEq
-
-structure TensorScalar where
-  op0 : AluOp
-  const0 : Float
-  reverse0 : Bool
-  op1 : AluOp
-  const1 : Float
-  reverse1 : Bool
-  deriving Repr, BEq
-
-inductive Operator where
-  | tensorScalar : TensorScalar -> Operator
   deriving Repr, BEq
 
 inductive Expr where

--- a/KLR/Core/FromToJson.lean
+++ b/KLR/Core/FromToJson.lean
@@ -61,6 +61,7 @@ instance : FromJson Engine where
   | .str s => throw s!"unknown engine type {s}"
   | _ => throw "expecting engine type"
 
+deriving instance ToJson for Dtype
 deriving instance ToJson for AluOp
 deriving instance ToJson for Memory
 deriving instance ToJson for TensorName
@@ -68,6 +69,7 @@ deriving instance ToJson for Const
 deriving instance ToJson for IndexExpr
 deriving instance ToJson for Index
 
+deriving instance FromJson for Dtype
 deriving instance FromJson for AluOp
 deriving instance FromJson for Memory
 deriving instance FromJson for TensorName

--- a/KLR/Core/Operators.lean
+++ b/KLR/Core/Operators.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+
+/-
+# Definition of operators
+
+Operators can appear in a call node, and can be thought of as functions that
+take arguments and return results. However, an operator may have several
+variations, and these variations show up as parameters within the operator and
+not as arguments of the call node. A typical example is:
+
+  .store t [] (.call (.operator (.tensorScalar ts)) [a,b] [])
+
+where `ts` contains the tensor scalar parameters:
+
+  let ts := TensorScalar { op0 := .add, ..}
+  let ts := TensorScalar { op0 := .multiply, op1 := add, ..}
+
+The choice of argument or parameter may seem arbitrary; these definitions
+follow the hardware ISA as close as possible.
+-/
+namespace KLR.Core
+
+-- Compute Engines
+inductive Engine where
+  | unassigned
+  | act | dma | dve | pe | pool | sp
+  deriving BEq, Repr
+
+-- Memory types
+inductive Memory where
+  | dram | sbuf | pmem | reg
+  deriving Repr, BEq
+
+/-
+Tensor element types supported by HW and available from NKI.
+
+The HW always performs operations on 32-bit types. However, when reading from
+or writing to memory, automatic conversion to and from the following types is
+supported.
+-/
+inductive Dtype where
+  | bfloat16
+  | float8e3 | float8e4 | float8e5
+  | float16 | float32 | float32r
+  | int8 | int16 | int64 | int32
+  | uint8 | uint16 | uint32 | uint64
+  with
+    @[computed_field]
+    size : Dtype -> Nat
+    | .uint8 | .int8 | .float8e3 | .float8e4 | .float8e5 => 1
+    | .uint16 | .int16 | .bfloat16 | .float16 => 2
+    | .uint32 | .int32 | .float32 | .float32r => 4
+    | .uint64 | .int64 => 8
+  deriving Repr, BEq
+
+-- ALU operations supported by the HW
+-- TODO organize these into groups to make seantic checking easier
+inductive AluOp where
+  | abs
+  | add
+  | arith_shift_left
+  | arith_shift_right
+  | average
+  | bitwise_and
+  | bitwise_not
+  | bitwise_or
+  | bitwise_xor
+  | bypass
+  | divide
+  | elemwise_mul
+  | is_equal
+  | is_ge
+  | is_gt
+  | is_le
+  | is_lt
+  | logical_and
+  | logical_or
+  | logical_shift_left
+  | logical_shift_right
+  | logical_xor
+  | max
+  | min
+  | mod
+  | mult
+  | not_equal
+  | pow
+  | rsqrt
+  | subtract
+  deriving BEq, Repr
+
+-- Tensor-Scalar operator
+-- TODO: this is gen1 only, add gen2
+structure TensorScalar where
+  op0 : AluOp
+  const0 : Float
+  reverse0 : Bool
+  op1 : AluOp
+  const1 : Float
+  reverse1 : Bool
+  deriving Repr, BEq
+
+-- All of the operators
+inductive Operator where
+  | tensorScalar : TensorScalar -> Operator
+  deriving Repr, BEq

--- a/KLR/Core/Pretty.lean
+++ b/KLR/Core/Pretty.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul Govereau, Sean McLaughlin
 -/
 import KLR.Core.Basic
+import KLR.Util
 
 namespace KLR.Core
 open Std
@@ -88,9 +89,14 @@ def ppStmt : Stmt -> Format
   | .assign x e => x ++ " = " ++ ppExpr e
   | .loop _ _ _ _ _ => "<loop>"
 
+def ppDtype (dty : Dtype) : Format :=
+  match (reprStr dty).toName with
+  | .str _ name => name
+  | _ => impossible "dtype repr must be a name"
+
 def ppFullTensor (t : TensorName) : Format :=
   t.name ++ abracket (.joinSep [
-    format t.dtype,
+    ppDtype t.dtype,
     .paren (.joinSep t.shape ","),
     ppMemory t.memory
     ] ",")
@@ -107,6 +113,7 @@ def ppKernel (k : Kernel) : Format :=
     "body:", nest_lines (k.body.map ppStmt)
   ]
 
+instance : ToFormat Dtype      where format := ppDtype
 instance : ToFormat TensorName where format := ppTensor
 instance : ToFormat Const      where format := ppConst
 instance : ToFormat IndexExpr  where format := ppIndexExpr 0

--- a/KLR/Python.lean
+++ b/KLR/Python.lean
@@ -218,7 +218,8 @@ where
     let f <- k.funcs.lookup k.entry
     let args := f.args.required
     let ten := Expr.exprPos (.const (.int 10)) {}
-    let tensors := args.map fun _ => .tensor [ten,ten] "float32"
+    let dtype := "nki.language.float32"
+    let tensors := args.map fun _ => .tensor [ten,ten] dtype
     return tensors
 
 -------------------------------------------------------------------------------

--- a/KLR/Trace/Basic.lean
+++ b/KLR/Trace/Basic.lean
@@ -259,12 +259,14 @@ where
 
 def Term.attr : Term -> String -> TraceM Term
   | .object o, id => o.attr id
-  | .expr _ (.tensor d _), "dtype" => return (str d)
+  | .expr _ (.tensor d _), "dtype" => return (dtype d)
   | .expr _ (.tensor _ s), "shape" => return (list s)
   | .expr e _, id => throw s!"unsupported attribute {id} on {repr e}"
   | t, id => throw s!"unsupported attribute {id} on {repr t}"
 where
-  str s  := .expr (.const $ .string s) .string
+  dtype dty :=
+    let name := "nki.language." ++ toString (Std.format dty)
+    .expr (.var name) (.obj name.toName)
   list l := .list $ l.map fun i => .expr (.const (.int $ .ofNat i)) .int
 
 def Item.attr : Item -> String -> Tracer Item

--- a/KLR/Trace/FromNKI.lean
+++ b/KLR/Trace/FromNKI.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+import KLR.Core
+import KLR.Trace.Types
+import KLR.Util
+
+/-
+Typeclass for conversion from NKI representation.
+-/
+
+namespace KLR.Trace
+open KLR.Core
+
+class FromNKI (a : Type) where
+  fromNKI? : Term -> Err a
+
+export FromNKI (fromNKI?)
+
+def fromNKI [FromNKI a] (dflt : a) (t : Term) : a :=
+  match fromNKI? t with
+  | .ok x => x
+  | .error _ => dflt
+
+instance [FromNKI a] : FromNKI (List a) where
+  fromNKI?
+  | .tuple l | .list l => fromNKI? ▷ l
+  | _ => throw "expecting sequence (list or tuple)"
+
+instance [FromNKI a] : FromNKI (Option a) where
+  fromNKI?
+    | .expr (.const .none) _ => return none
+    | e => return some (<- fromNKI? e)
+
+instance : FromNKI Bool where
+  fromNKI?
+    | .expr (.const (.bool b)) .bool => return b
+    | _ => throw "expecting boolean"
+
+instance : FromNKI Int where
+  fromNKI?
+    | .expr (.const (.int i)) .int => return i
+    | _ => throw "expecting integer"
+
+instance : FromNKI Nat where
+  fromNKI? t :=
+    let err := .error "expecting positive number"
+    match fromNKI? (a := Int) t with
+    | .ok i => if i < 0 then err else .ok i.toNat
+    | .error _ => err
+
+instance : FromNKI Float where
+  fromNKI?
+    | .expr (.const (.float f)) .float => return f
+    | _ => throw "expecting float"
+
+instance : FromNKI String where
+  fromNKI?
+    | .expr (.const (.string s)) .string => return s
+    | _ => throw "expecting string"
+
+-- TODO: when new NKI API is settled, rewrite is a nicer way
+instance : FromNKI Dtype where
+  fromNKI?
+    | .expr (.var name) _ =>
+      match name with
+      -- NKI variants (see table in NKI docs)
+      | "nki.language.uint8" => .ok .uint8
+      | "nki.language.int8" => .ok .int8
+      | "nki.language.uint16" => .ok .uint16
+      | "nki.language.int16" => .ok .int16
+      | "nki.language.uint32" => .ok .int32
+      | "nki.language.int32" => .ok .int32
+      | "nki.language.float8e3" => .ok .float8e3
+      | "nki.language.float8e4" => .ok .float8e4
+      | "nki.language.float8e5" => .ok .float8e5
+      | "nki.language.float8_e4m3" => .ok .float8e4
+      | "nki.language.float8_e5m2" => .ok .float8e5
+      | "nki.language.float16" => .ok .float16
+      | "nki.language.bfloat16" => .ok .bfloat16
+      | "nki.language.tfloat32" => .ok .float32r  -- TODO check this
+      | "nki.language.float32" => .ok .float32
+      | "nki.language.bool_" => .ok .uint8
+      -- numpy variants
+      | "numpy.uint8" => .ok .uint8
+      | "numpy.int8" => .ok .int8
+      | "numpy.uint16" => .ok .uint16
+      | "numpy.int16" => .ok .int16
+      | "numpy.uint32" => .ok .uint32
+      | "numpy.int32" => .ok .int32
+      | "numpy.float16" => .ok .float16
+      | "numpy.float32" => .ok .float32
+      | "numpy.bool" => .ok .uint8
+      -- imported variants
+      | "uint8" => .ok .uint8
+      | "int8" => .ok .int8
+      | "uint16" => .ok .uint16
+      | "int16" => .ok .int16
+      | "uint32" => .ok .int32
+      | "int32" => .ok .int32
+      | "float8e3" => .ok .float8e3
+      | "float8e4" => .ok .float8e4
+      | "float8e5" => .ok .float8e5
+      | "float8_e4m3" => .ok .float8e4
+      | "float8_e5m2" => .ok .float8e5
+      | "float16" => .ok .float16
+      | "bfloat16" => .ok .bfloat16
+      | "tfloat32" => .ok .float32r  -- TODO check this
+      | "float32" => .ok .float32
+      | "bool" => .ok .uint8
+      | s => throw s!"unsupported dtype {s}"
+    | .expr (.const (.string str)) _ =>
+      match str with
+      | "uint8" => .ok .uint8
+      | "int8" => .ok .int8
+      | "uint16" => .ok .uint16
+      | "int16" => .ok .int16
+      | "uint32" => .ok .int32
+      | "int32" => .ok .int32
+      | "float8e3" => .ok .float8e3
+      | "float8e4" => .ok .float8e4
+      | "float8e5" => .ok .float8e5
+      | "float8_e4m3" => .ok .float8e4
+      | "float8_e5m2" => .ok .float8e5
+      | "float16" => .ok .float16
+      | "bfloat16" => .ok .bfloat16
+      | "tfloat32" => .ok .float32r  -- TODO check this
+      | "float32" => .ok .float32
+      | "bool" => .ok .uint8
+      | s => throw s!"unsupported dtype name {s}"
+    | _ => throw s!"expecting dtype"
+
+instance : FromNKI Shape where
+  fromNKI? := fromNKI? (a := List Nat)
+
+instance : FromNKI Memory where
+  fromNKI? t :=
+    let err := .error "expecting buffer type"
+    match t with
+    | .expr (.var name) _ =>
+      match name with
+      | "nki.language.shared_hbm" => .ok .dram
+      | "nki.language.sbuf" => .ok .sbuf
+      | "nki.language.pmem" => .ok .pmem
+      | _ => err
+    | _ => err
+
+instance : FromNKI AluOp where
+  fromNKI?
+    | .expr (.var name) _ =>
+        match name with
+        -- bitwise operations
+        | "nki.language.invert" => return .bitwise_not
+        | "nki.language.bitwise_and" => return .bitwise_and
+        | "nki.language.bitwise_or" => return .bitwise_or
+        | "nki.language.bitwise_xor" => return .bitwise_xor
+        | "nki.language.left_shift" => return .logical_shift_left
+        | "nki.language.right_shift" => return .logical_shift_right
+        -- numpy variants
+        | "numpy.bitwise_not" => return .bitwise_not
+        | "numpy.bitwise_invert" => return .bitwise_not
+        | "numpy.bitwise_and" => return .bitwise_and
+        | "numpy.bitwise_or" => return .bitwise_or
+        | "numpy.bitwise_xor" => return .bitwise_xor
+        | "numpy.bitwise_left_shift" => return .logical_shift_left
+        | "numpy.bitwise_right_shift" => return .logical_shift_right
+        -- arithemetic operations
+        | "nki.language.add" => return .add
+        | "nki.language.subtract" => return .subtract
+        | "nki.language.multiply" => return .mult
+        | "nki.language.maximum" => return .max
+        | "nki.language.minimum" => return .min
+        | "nki.language.equal" => return .is_equal
+        | "nki.language.not_equal" => return .not_equal
+        | "nki.language.greater_equal" => return .is_ge
+        | "nki.language.greater" => return .is_gt
+        | "nki.language.less_equal" => return .is_le
+        | "nki.language.less" => return .is_lt
+        | "nki.language.logical_not" => throw "??"
+        | "nki.language.logical_and" => return .logical_and
+        | "nki.language.logical_or" => return .logical_or
+        | "nki.language.logical_xor" => return .logical_xor
+        -- numpy variants
+        | "numpy.add" => return .add
+        | "numpy.subtract" => return .subtract
+        | "numpy.multiply" => return .mult
+        | "numpy.maximum" => return .max
+        | "numpy.minimum" => return .min
+        | "numpy.equal" => return .is_equal
+        | "numpy.not_equal" => return .not_equal
+        | "numpy.greater_equal" => return .is_ge
+        | "numpy.greater" => return .is_gt
+        | "numpy.less_equal" => return .is_le
+        | "numpy.less" => return .is_lt
+        | "numpy.logical_not" => throw "??"
+        | "numpy.logical_and" => return .logical_and
+        | "numpy.logical_or" => return .logical_or
+        | "numpy.logical_xor" => return .logical_xor
+        | _ => throw s!"unsupported operator {name}"
+    | _ => throw "expecting operator"

--- a/KLR/Trace/Numpy.lean
+++ b/KLR/Trace/Numpy.lean
@@ -16,6 +16,16 @@ open KLR.Trace.Builtin
 private def numpy : Name := .str .anonymous "numpy"
 private def np : String -> Name := .str numpy
 
-def NumpyEnv : List (Name × Item) :=
-  [ module numpy
+-- We are only using numpy to name operators
+-- This will be changed in upcoming NKI API and we will not need this.
+private def syms := [
+  "uint8" , "int8" , "uint16" , "int16" , "uint32" , "int32" , "float16" , "float32" , "bool",
+  "bitwise_not", "bitwise_invert", "bitwise_and", "bitwise_or", "bitwise_xor",
+  "bitwise_left_shift", "bitwise_right_shift",
+  "add", "subtract", "multiply", "maximum", "minimum",
+  "equal", "not_equal", "greater_equal", "greater", "less_equal", "less",
+  "logical_not", "logical_and", "logical_or", "logical_xor"
   ]
+
+def NumpyEnv : List (Name × Item) :=
+  module numpy :: syms.map fun s => const_var (np s)

--- a/KLR/Trace/Python.lean
+++ b/KLR/Trace/Python.lean
@@ -282,6 +282,7 @@ partial def expr' : Expr' -> Tracer Item
   | .tensor s dty => do
       let shape <- nat ▷ s
       let name <- genName "t".toName
+      let dty <- fromNKI? (.expr (.var dty) .none)
       return .term (.expr (.tensor ⟨ name.toString, dty, shape, .dram ⟩) (.tensor dty shape))
   | .name id _ => lookup_item id.toName
   | .attr (.exprPos e p) id _ => do withPos p ((<- expr' e).attr id)

--- a/KLR/Trace/Types.lean
+++ b/KLR/Trace/Types.lean
@@ -142,6 +142,9 @@ inductive Term where
   | expr     : Expr -> TermType -> Term
 end
 
+instance : Inhabited Term where
+  default := .expr (.const .none) .none
+
 def Term.format : Term -> Lean.Format
   | .object obj => .text s!"object<{obj.name}>"
   | .tuple l => .text s!"tuple<{l.length}>"
@@ -253,7 +256,7 @@ def lookup? (name : Name) : TraceM (Option Term) := do
 
 def lookup (name : Name) : TraceM Term := do
   match (<- lookup? name) with
-  | none => throw s!"{name} not found"
+  | none => throw s!"local name {name} not found"
   | some x => return x
 
 
@@ -366,7 +369,7 @@ def lookup_global? (name : Name) : Tracer (Option Item) := do
 
 def lookup_global (name : Name) : Tracer Item := do
   match (<- get).env.find? name with
-  | none => throw s!"{name} not found"
+  | none => throw s!"global name {name} not found"
   | some x => return x
 
 def lookup_item (name : Name) : Tracer Item := do

--- a/interop/test/test_basic.py
+++ b/interop/test/test_basic.py
@@ -142,7 +142,7 @@ def undefined_ok(t):
   undefined_ok
   ])
 def test_succeed(f):
-  t = np.ndarray(10)
+  t = np.ndarray(10, dtype="float32")
   F = Parser(f)   # parse python
   F(t)            # specialize, and reduce to KLR
 


### PR DESCRIPTION
This patch fills in the implementation of tensor_scalar, and also refactors some code to make this easier. The main change is the introduction of specific element types (`Dtype`) as specified in the NKI docs.