### PR TITLE
refactor: remove Object type and Tracer monad

### DIFF
--- a/KLR/Python.lean
+++ b/KLR/Python.lean
@@ -20,7 +20,7 @@ structure Pos where
   end_lineno : Nat := 0
   col_offset : Nat := 0
   end_col_offset : Nat := 0
-  deriving Repr
+  deriving Repr, BEq
 
 inductive Const where
   | none
@@ -289,7 +289,7 @@ def genError (offset : Nat) (source err : String) (pos : Pos) : String :=
               then "<source not available>"
               else lines[lineno]!
   let indent := (Nat.repeat (List.cons ' ') colno List.nil).asString
-  s!"line {lineno + offset}:\n{line}\n{indent}^-- {err}"
+  s!"\nline {lineno + offset}:\n{line}\n{indent}^-- {err}"
 
 private def withSrc (line : Nat) (source : String) (p : Parser a) : Parser a :=
   try set { lineno := 0 : Pos } ; p

--- a/KLR/Trace.lean
+++ b/KLR/Trace.lean
@@ -16,5 +16,5 @@ namespace KLR.Trace
 
 def globalEnv := PythonEnv ++ NKIEnv ++ NumpyEnv
 
-def runNKIKernel (k : KLR.Python.Kernel) : Err KLR.Core.Kernel :=
-  tracer ⟨ .ofList globalEnv, #[] ⟩ (traceKernel k)
+def runNKIKernel (k : KLR.Python.Kernel) : Err (String × KLR.Core.Kernel) :=
+  tracer globalEnv (traceKernel k)

--- a/KLR/Trace/Builtin.lean
+++ b/KLR/Trace/Builtin.lean
@@ -7,7 +7,7 @@ import KLR.Core
 import KLR.Trace.Types
 
 /-
-# Utilities for creating Builtins and Globals
+# Utilities for creating Builtins
 
 -/
 
@@ -16,20 +16,17 @@ open KLR.Core
 
 namespace Builtin
 
-def module (name : Name) : Name × Item :=
+def module (name : Name) : Name × Term :=
   (name, .module name)
 
-def const_var (name: Name) : Name × Item :=
-  (name, .term (.expr (.var name.toString) (.obj name)))
+def const_var (name: Name) : Name × Term :=
+  (name, .expr (.var name.toString) (.obj name))
 
-def global (g : Global) : Name × Item :=
-  (g.name, .global g)
+def const_int (name: Name) (i : Int) : Name × Term :=
+  (name, .expr (.const (.int i)) .int)
 
-abbrev BuiltinAttr := String -> Err Term
-abbrev GlobalAttr  := String -> TraceM Term
-
-abbrev BuiltinFn := List Expr -> List (String × Expr) -> Err Term
-abbrev GlobalFn  := List Term -> List (String × Term) -> TraceM Term
+abbrev BuiltinAttr := String -> Trace Term
+abbrev BuiltinFn := List Term -> List (String × Term) -> Trace Term
 
 /-
 Fetch the (Python) arguments given in `pos` and `kw` according to the
@@ -53,139 +50,3 @@ def withArgs [Monad m] [MonadExcept String m] [MonadLift Err m]
              (names : List (String × Option a)) (f : List a -> m b)
              (args : List a) (kwargs : List (String × a)) : m b :=
     do f (<- getArgs names args kwargs)
-
-def noAttr [Monad m] [MonadExcept String m] : Name -> String -> m a :=
-  fun name attr => throw s!"{attr} is not an attribute of {name}"
-
-def noAccess [Monad m] [MonadExcept String m] : Name -> a -> m b :=
-  fun name _ => throw s!"{name} does not support subscript"
-
-def noIndex [Monad m] [MonadExcept String m] : Name -> a -> b -> m c :=
-  fun name _ _ => throw s!"{name} cannot be used as an index"
-
-def noBinop [Monad m] [MonadExcept String m] : Name -> a -> BinOp -> b -> m c :=
-  fun name _ op _ => throw s!"{name} does not support operator {repr op}"
-
-def uncallable [Monad m] [MonadExcept String m] : Name -> a -> b -> m c :=
-  fun name _ _ => throw s!"{name} is not a callable type"
-
--- Note, this is more strict that python
-def noKWArgs [Monad m] [MonadExcept String m]
-              (f : List a -> m b) : (List a -> List c -> m b) :=
-  fun args kwargs =>
-    if kwargs.length > 0 then
-      throw "invalid arguments (no kwargs supported)"
-    else f args
-
--- Create a simple global function; no attributes supported
-
-def global_fn (name : Name) (f : GlobalFn) : Global :=
-  { name := name
-  , attr := noAttr name
-  , call := f
-  }
-
-def globalFn n f := global (global_fn n f)
-
--- Create a built-in representing a function; no attributes supported.
-
-def simple_function (name : Name) (f : BuiltinFn) : Object :=
-  { name := name
-  , type := .obj name  -- TODO: use a function type
-  , attr := noAttr name
-  , access := noAccess name
-  , index := noIndex name
-  , binop := noBinop name
-  , call := f
-  }
-
--- Create a built-in representing a function; basic attributes supported.
-
-def python_function (name : Name) (f : BuiltinFn) : Object :=
-  { name := name
-  , type := .obj name  -- TODO: use a function type
-  , attr := attrs
-  , access := noAccess name
-  , index := noIndex name
-  , binop := noBinop name
-  , call := f
-  }
-where
-  attrs : BuiltinAttr
-  | "__name__" => return .expr (.const $ .string name.toString) .string
-  | "__call__" => return .object (simple_function name f)
-  | a => throw s!"unsupported attribute {a}"
-
--- Create a built-in representing a simple object from a list of attributes.
-
-def simple_object {a : Type}
-                  (name : Name)
-                  (attrs : List (String × (a -> BuiltinFn)))
-                  (x : a) : Object :=
-  { name := name
-  , type := .none
-  , attr := attr_fn
-  , access := noAccess name
-  , index := noIndex name
-  , binop := noBinop name
-  , call := uncallable name
-  }
-where
-  attr_fn (attr : String) : Err Term :=
-    match attrs.find? (fun x => x.fst == attr) with
-    | none => .error s!"{attr} is not an attribute of {name}"
-    | some (_,fn) => .ok (.object $ simple_function (name.str attr) (fn x))
-
-
--- Basic Python types could be represented as built-ins. In practice, we don't
--- do this as it is more convenient to have tuples, etc. represented directly
--- in the `Term` type. However, as an example, the tuple class may be defined
--- similar to below.
-
--- Note: not used
-def tuple_obj : List Term -> Object :=
-  simple_object "tuple".toName
-    [ ("count", fun l _ _ => .ok (.expr (.const $ .int l.length) .int))
-    , ("index", index_fn)
-    ]
-where
-  index_fn : List Term -> BuiltinFn
-  | l, [x], [] => match l.indexOf? (.expr x .none) with
-                  | none => throw s!"{repr x} not in tuple"
-                  | some i => return .expr (.const $ .int i) .int
-  | _, _, _ => throw "invalid arguments"
-
--- Note: not used
-def tuple_class : Global :=
-  let name := "class_tuple".toName
-  { name := name
-  , attr := noAttr name
-  , call := make_tuple
-  }
-where
-  make_tuple : GlobalFn
-  | args, [] => return .object (tuple_obj args)
-  | _, _ => throw "invalid arguments"
-
-end Builtin
-
--- A convenience class for building Objects
-
-class Obj (a : Type) where
-  name : Name
-  type : TermType := .obj name
-  attr : a -> String -> Err Term := fun _ => Builtin.noAttr name
-  access : a -> List Index -> Err Term := fun _ => Builtin.noAccess name
-  index : a -> TermType -> Nat -> Err Index := fun _ => Builtin.noIndex name
-  binop : a -> Bool -> BinOp -> Expr -> Err Term := fun _ => Builtin.noBinop name
-  call : a -> List Expr -> List (String × Expr) -> Err Term := fun _ => Builtin.uncallable name
-
-def toObject [inst: Obj a] (x : a) : Object :=
-  { name := inst.name
-  , type := inst.type
-  , attr := inst.attr x
-  , access := inst.access x
-  , index := inst.index x
-  , binop := inst.binop x
-  , call := inst.call x
-  }

--- a/KLR/Trace/FromNKI.lean
+++ b/KLR/Trace/FromNKI.lean
@@ -34,6 +34,21 @@ instance [FromNKI a] : FromNKI (Option a) where
     | .expr (.const .none) _ => return none
     | e => return some (<- fromNKI? e)
 
+instance : FromNKI Term where
+  fromNKI? t := .ok t
+
+instance : FromNKI Expr where
+  fromNKI?
+    | .module _    => throw "module cannot be converted to a KLR term"
+    | .builtin n _ => return .var n.toString
+    | .source _    => throw "function cannot be converted to a KLR term"
+    | .tuple _     => throw "tuple cannot be converted to a KLR term"
+    | .list _      => throw "list cannot be converted to a KLR term"
+    | .ellipsis    => throw "ellipsis cannot be converted to a KLR term"
+    | .slice _ _ _ => throw "slice cannot be converted to KLR in this context"
+    | .store _ _ _ => throw "store cannot be converted to KLR in this context"
+    | .expr e _    => return e
+
 instance : FromNKI Bool where
   fromNKI?
     | .expr (.const (.bool b)) .bool => return b
@@ -41,6 +56,8 @@ instance : FromNKI Bool where
 
 instance : FromNKI Int where
   fromNKI?
+    | .expr (.const (.bool true)) _ => return 1
+    | .expr (.const (.bool false)) _ => return 0
     | .expr (.const (.int i)) .int => return i
     | _ => throw "expecting integer"
 

--- a/KLR/Trace/Numpy.lean
+++ b/KLR/Trace/Numpy.lean
@@ -27,5 +27,5 @@ private def syms := [
   "logical_not", "logical_and", "logical_or", "logical_xor"
   ]
 
-def NumpyEnv : List (Name × Item) :=
+def NumpyEnv : List (Name × Term) :=
   module numpy :: syms.map fun s => const_var (np s)

--- a/KLR/Util.lean
+++ b/KLR/Util.lean
@@ -12,24 +12,20 @@ namespace KLR
 The default choice for an error monad is `Except String`, used for simple
 computations that can fail.
 
-This is defined as a notation so that it can be used within mutually recursive
-inductive types without issues. (abbrev introduces a new definition which
-cannot be used in a mutually recursive inductive)
+Provide automatic lifting of Err to any monad that supports throwing strings
+as errors.
 -/
-notation "Err" => Except String
+abbrev Err := Except String
+
+instance [Monad m] [MonadExcept String m] : MonadLift Err m where
+  monadLift
+    | .ok x => return x
+    | .error s => throw s
 
 /-
 The default choice for a state monad is `EStateM String`.
-Again, we use a notation for the same reason as for `Err`.
-
-Provide automatic lifting of Err, for any state monad instance.
 -/
-notation "StM" => EStateM String
-
-instance : MonadLift Err (StM a) where
-  monadLift
-    | .ok x => .ok x
-    | .error s => .error s
+abbrev StM := EStateM String
 
 /-
 A common issue is failure to prove termination automatically when using
@@ -46,4 +42,5 @@ Note: ▷ is typed as \rhd
 notation f "▷" l =>
   List.mapM (fun ⟨ x, _ ⟩ => f x) (List.attach l)
 
-def impossible {a : Type} [h : Inhabited a] (msg : String := "") := @panic a h s!"Invariant violation: {msg}"
+def impossible {a : Type} [h : Inhabited a] (msg : String := "") :=
+  @panic a h s!"Invariant violation: {msg}"

--- a/Main.lean
+++ b/Main.lean
@@ -128,15 +128,16 @@ private def parse (p : Parsed) : IO KLR.Python.Kernel := do
 
 def parseJson (p : Parsed) : IO UInt32 := do
   let kernel <- parse p
-  let klr <- KLR.Trace.runNKIKernel kernel.inferArguments
+  let (_, klr) <- KLR.Trace.runNKIKernel kernel.inferArguments
   let json := Lean.toJson klr
   IO.println json
   return 0
 
 def trace (p : Parsed) : IO UInt32 := do
   let kernel <- parse p
-  let klr <- KLR.Trace.runNKIKernel kernel.inferArguments
+  let (warnings, klr) <- KLR.Trace.runNKIKernel kernel.inferArguments
   if p.hasFlag "pretty" then
+    IO.println warnings
     IO.println (toString $ Std.format klr)
   else
     showAs p klr
@@ -152,7 +153,7 @@ def parseBIR (p : Parsed) : IO UInt32 := do
 
 def compileStr (s : String) : Err KLR.BIR.BIR := do
   let kernel <- KLR.Python.Parsing.parse s
-  let klr <- KLR.Trace.runNKIKernel kernel.inferArguments
+  let (_, klr) <- KLR.Trace.runNKIKernel kernel.inferArguments
   KLR.BIR.compile klr
 
 def compile (p : Parsed) : IO UInt32 := do


### PR DESCRIPTION
This change removes the ability to place lean functions inside the trace environment, and simplifies the trace monad types. Builtin functions are now represented in the environment by their unique names. When a builtin is encountered, we use the name to dispatch to the correct lean function. This dispatching is fixed and cannot be changed at runtime.