### PR TITLE
refactor: simplify KLR based on new loop design

### DIFF
--- a/KLR/BIR/Instruction.lean
+++ b/KLR/BIR/Instruction.lean
@@ -16,7 +16,7 @@ Note: the naming of fields is carefully designed so that the derived
 instances of to- and from-json are compatible with the compiler.
 -/
 namespace KLR.BIR
-export KLR.Core (Dtype Shape Engine AluOp Memory)
+export KLR.Core (Dtype Shape Engine AluOp Memory APPair)
 
 -- TODO: this is incomplete
 structure QAETerm where
@@ -36,11 +36,6 @@ inductive InstSyncType where
   | DataPathType
   | SequencerType
   | DMAType
-  deriving BEq, Repr, Lean.FromJson, Lean.ToJson
-
-structure APPair where
-  step : Int := 1
-  num : Nat := 1
   deriving BEq, Repr, Lean.FromJson, Lean.ToJson
 
 structure PhysicalAccessPattern where

--- a/KLR/Core/FromToJson.lean
+++ b/KLR/Core/FromToJson.lean
@@ -65,26 +65,28 @@ deriving instance ToJson for Dtype
 deriving instance ToJson for AluOp
 deriving instance ToJson for Memory
 deriving instance ToJson for TensorName
-deriving instance ToJson for Const
-deriving instance ToJson for IndexExpr
 deriving instance ToJson for Index
+deriving instance ToJson for APPair
+deriving instance ToJson for Access
 
 deriving instance FromJson for Dtype
 deriving instance FromJson for AluOp
 deriving instance FromJson for Memory
 deriving instance FromJson for TensorName
-deriving instance FromJson for Const
-deriving instance FromJson for IndexExpr
 deriving instance FromJson for Index
+deriving instance FromJson for APPair
+deriving instance FromJson for Access
 
 deriving instance ToJson for TensorScalar
 deriving instance ToJson for Operator
+deriving instance ToJson for Value
 deriving instance ToJson for Expr
 deriving instance ToJson for Stmt
 deriving instance ToJson for Kernel
 
 deriving instance FromJson for TensorScalar
 deriving instance FromJson for Operator
+deriving instance FromJson for Value
 deriving instance FromJson for Expr
 deriving instance FromJson for Stmt
 deriving instance FromJson for Kernel

--- a/KLR/Core/Operators.lean
+++ b/KLR/Core/Operators.lean
@@ -105,5 +105,6 @@ structure TensorScalar where
 
 -- All of the operators
 inductive Operator where
+  | named : String -> Operator
   | tensorScalar : TensorScalar -> Operator
   deriving Repr, BEq

--- a/KLR/Trace/Builtin.lean
+++ b/KLR/Trace/Builtin.lean
@@ -20,10 +20,10 @@ def module (name : Name) : Name × Term :=
   (name, .module name)
 
 def const_var (name: Name) : Name × Term :=
-  (name, .expr (.var name.toString) (.obj name))
+  (name, .expr (.value $ .var name.toString) (.obj name))
 
 def const_int (name: Name) (i : Int) : Name × Term :=
-  (name, .expr (.const (.int i)) .int)
+  (name, .expr (.value $ .int i) .int)
 
 abbrev BuiltinAttr := String -> Trace Term
 abbrev BuiltinFn := List Term -> List (String × Term) -> Trace Term

--- a/interop/test/test_basic.py
+++ b/interop/test/test_basic.py
@@ -51,7 +51,7 @@ def expr_list(t):
 
 def expr_subscript(t):
   t[1]
-  t[1,2,3]
+  #t[1,2,3]
   t[1:2:3]
   t[1:2]
   t[1:]
@@ -60,10 +60,11 @@ def expr_subscript(t):
   t[1:2:None]
   t[1:None:2]
   t[:]
-  t[:,:]
+  #t[:,:]
   t[...]
   t[1,...]
-  t[:,None]
+  t[...,1]
+  #t[:,None]
   t[1]
 
 def expr_bool_op(t):


### PR DESCRIPTION
This change removes IndexExpr and adds a hardware-based access method (Access.pattern). This change is motivated by the new loop semantics which does not include an explicit affine loop. A future change will add a fully dynamic loop and related access forms.