### PR TITLE
feat: allow unknown functions in KLR

### DIFF
--- a/KLR/BIR/Compile/Kernel.lean
+++ b/KLR/BIR/Compile/Kernel.lean
@@ -17,25 +17,16 @@ def gatherAPs : List Expr -> Compile (List Argument)
     | .value (.access a) => return .PhysicalAccessPattern (<- accessToAP a) :: xs
     | _ => return xs
 
-def compileStore (dst : Access) (e : Expr) : Compile Inst := do
-  match e with
-  | .value (.access _) =>
-      return .TensorLoad {
-        name := "load_test"  -- I think these have to be unique (need state monad?)
-        ins  := <- gatherAPs [e]
-        outs := <- gatherAPs [.value (.access dst)]
-      }
-  | .call _ args => do
-      return .NoOp {
-        name := "noop_test"  -- I think these have to be unique (need state monad?)
-        ins  := <- gatherAPs (args.map .value)
-        outs := <- gatherAPs [.value (.access dst)]
-      }
-  | _ => throw s!"store pattern not yet implemented {repr e}"
+def compileStore (dst : Access) (_op : Operator) (args : List Core.Value) : Compile Inst := do
+  return .NoOp {
+    name := "noop_test"  -- I think these have to be unique (need state monad?)
+    ins  := <- gatherAPs (args.map .value)
+    outs := <- gatherAPs [.value (.access dst)]
+  }
 
 def compileStmt : Stmt -> Compile Inst
   | .ret _ => throw "unimp ret"
-  | .store dst e => compileStore dst e
+  | .store dst op args => compileStore dst op args
   | .assign .. => throw "unimp assign"
 
 def compile_kernel (k : Kernel) : Compile BIR := do

--- a/KLR/Core/Pretty.lean
+++ b/KLR/Core/Pretty.lean
@@ -25,6 +25,9 @@ private def args [ToFormat a] (l : List a) : Format :=
 private def sqArgs [ToFormat a] (l : List a) : Format :=
   .sbracket (.joinSep l ",")
 
+instance [ToFormat a] [ToFormat b] : ToFormat (a × b) where
+  format | (a,b) => .paren (format a ++ "," ++ format b)
+
 instance : ToFormat Memory where
   format
   | .dram => "dram"
@@ -74,13 +77,13 @@ instance : ToFormat Value where
 instance : ToFormat Expr where
   format
   | .value v => format v
-  | .call f a => format f ++ args a
+  | .call f a k => format f ++ args (a ++ k.map Prod.snd)
 
 instance : ToFormat Stmt where
   format
-  | .ret e      => "ret" ++ format e
+  | .ret e => "ret" ++ format e
   | .assign x e => x ++ " = " ++ format e
-  | .store d e  => format d ++ " := " ++ format e
+  | .store d op as => format d ++ " := " ++ format op ++ args as
 
 def ppFullTensor (t : TensorName) : Format :=
   t.name ++ sqArgs [ format t.dtype, args t.shape, format t.memory ]

--- a/KLR/Trace/FromNKI.lean
+++ b/KLR/Trace/FromNKI.lean
@@ -49,7 +49,7 @@ instance : FromNKI Expr where
     | .list _      => err "list"
     | .ellipsis    => err "ellipsis"
     | .slice _ _ _ => err "slice"
-    | .store _ _   => err "store"
+    | .store _ _ _ => err "store"
     | .expr e _    => return e
 
 instance : FromNKI Value where


### PR DESCRIPTION
This change makes a small change to KLR so that it can support unknown function calls. The store statement is changed so that it can only be used with an operator, and the call expression is used for unknown functions.