### PR TITLE
feat: add memory addresses to KLR and tracing

### DIFF
--- a/KLR/Core/FromToJson.lean
+++ b/KLR/Core/FromToJson.lean
@@ -61,20 +61,39 @@ instance : FromJson Engine where
   | .str s => throw s!"unknown engine type {s}"
   | _ => throw "expecting engine type"
 
+instance : ToJson Memory where
+  toJson
+  | .hbm => "dram"
+  | .sbuf => "sbuf"
+  | .pmem => "pmem"
+  | .reg => "reg"
+
+instance : FromJson Memory where
+  fromJson?
+  | .str "dram" => return .hbm
+  | .str "sbuf" => return .sbuf
+  | .str "pmem" => return .pmem
+  | .str "reg" => return .reg
+  | _ => throw "expecting memory type"
+
 deriving instance ToJson for Dtype
 deriving instance ToJson for AluOp
-deriving instance ToJson for Memory
+deriving instance ToJson for Shape
+deriving instance ToJson for Address
 deriving instance ToJson for TensorName
 deriving instance ToJson for Index
 deriving instance ToJson for APPair
+deriving instance ToJson for AccessPattern
 deriving instance ToJson for Access
 
 deriving instance FromJson for Dtype
 deriving instance FromJson for AluOp
-deriving instance FromJson for Memory
+deriving instance FromJson for Shape
+deriving instance FromJson for Address
 deriving instance FromJson for TensorName
 deriving instance FromJson for Index
 deriving instance FromJson for APPair
+deriving instance FromJson for AccessPattern
 deriving instance FromJson for Access
 
 deriving instance ToJson for TensorScalar

--- a/KLR/Core/Operators.lean
+++ b/KLR/Core/Operators.lean
@@ -32,7 +32,7 @@ inductive Engine where
 
 -- Memory types
 inductive Memory where
-  | dram | sbuf | pmem | reg
+  | hbm | sbuf | pmem | reg
   deriving Repr, BEq
 
 /-

--- a/KLR/Trace.lean
+++ b/KLR/Trace.lean
@@ -14,7 +14,21 @@ import KLR.Trace.Numpy
 
 namespace KLR.Trace
 
-def globalEnv := PythonEnv ++ NKIEnv ++ NumpyEnv
+-- Keywords recognized by the tracer (KLR keywords)
+-- Limits come from:
+-- https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/nki_arch_guides.html
+def keywords : List (Name × Term) :=
+  let ptr s memory size := (Lean.Name.mkStr1 s, Term.pointer { memory, size })
+  let const s := Builtin.const_var (.mkStr1 s)
+  let int s := Builtin.const_int (.mkStr1 s)
+  [ int "arch" 2
+  , const "hbm"
+  , ptr "sbuf" .sbuf (128, 0x30000)
+  , ptr "pmem" .pmem (128, 0x4000)
+  , const "range"
+  ]
+
+def globalEnv := keywords ++ NKIEnv ++ NumpyEnv
 
 def runNKIKernel (k : KLR.Python.Kernel) : Err (String × KLR.Core.Kernel) :=
   tracer globalEnv (traceKernel k)

--- a/KLR/Trace/Basic.lean
+++ b/KLR/Trace/Basic.lean
@@ -64,7 +64,8 @@ def Term.isTrue : Term -> Err Bool
   | .list _
   | .ellipsis
   | .slice ..
-  | .store .. => return true
+  | .store ..
+  | .pointer .. => return true
   | .expr (.value v) _ => return v.isTrue
   | .expr _ _ => throw "non-constant expression"
 
@@ -253,7 +254,7 @@ where
 def Term.attr : Term -> String -> Trace Term
   | .module n, id => lookup (n.str id)
   | .expr _ (.tensor d _), "dtype" => return (dtype d)
-  | .expr _ (.tensor _ s), "shape" => return (tuple s)
+  | .expr _ (.tensor _ s), "shape" => return (tuple s.toList)
   | _, id => throw s!"unsupported attribute {id}"
 where
   dtype dty :=

--- a/KLR/Trace/Builtin.lean
+++ b/KLR/Trace/Builtin.lean
@@ -19,8 +19,8 @@ namespace Builtin
 def module (name : Name) : Name × Term :=
   (name, .module name)
 
-def const_var (name: Name) : Name × Term :=
-  (name, .expr (.value $ .var name.toString) (.obj name))
+def const_var (name: Name) (ty : TermType := .obj name) : Name × Term :=
+  (name, .expr (.value $ .var name.toString) ty)
 
 def const_int (name: Name) (i : Int) : Name × Term :=
   (name, .expr (.value $ .int i) .int)

--- a/KLR/Trace/Tensor.lean
+++ b/KLR/Trace/Tensor.lean
@@ -27,7 +27,7 @@ def inferShape : Access -> Err Shape
     match l with
     | [] => return t.shape
     | ix => do
-        let base := t.shape
+        let base := t.shape.toList
         if base.length != ix.length then
           throw "unsupported index."
         let dims <- ix.mapM fun i =>
@@ -39,7 +39,8 @@ def inferShape : Access -> Err Shape
               if n <= 0 then throw "invalid step size"
               return ((e-s)/n).toNat
           | _ => throw s!"unsupported index"
-        return dims.filter (. != 0)
+        let shape <- Shape.fromList (dims.filter (. != 0))
+        return shape
   | a => return a.shape
 
 /-
@@ -65,8 +66,11 @@ def declare (tag : String)
     name := tname
     dtype := dtype
     shape := shape
-    memory := memory
+    address := {
+        memory := memory
+        size   := Address.defaultSize shape dtype
     }
+  }
 
 -- APIs
 

--- a/interop/test/test_basic.py
+++ b/interop/test/test_basic.py
@@ -51,7 +51,7 @@ def expr_list(t):
 
 def expr_subscript(t):
   t[1]
-  #t[1,2,3]
+  t[1,2]
   t[1:2:3]
   t[1:2]
   t[1:]
@@ -60,11 +60,12 @@ def expr_subscript(t):
   t[1:2:None]
   t[1:None:2]
   t[:]
-  #t[:,:]
+  t[:,:]
+  t[:,:,:]
   t[...]
   t[1,...]
   t[...,1]
-  #t[:,None]
+  t[:,None]
   t[1]
 
 def expr_bool_op(t):
@@ -144,7 +145,7 @@ def undefined_ok(t):
   undefined_ok
   ])
 def test_succeed(f):
-  t = np.ndarray(10, dtype="float32")
+  t = np.ndarray((10,10,10), dtype="float32")
   F = Kernel(f)   # parse python
   file = F(t)     # specialize, and reduce to KLR
   os.remove(file)

--- a/interop/test/test_memory.py
+++ b/interop/test/test_memory.py
@@ -1,0 +1,53 @@
+# tests of pointers and memory allocation
+
+import os
+from apis import *
+
+# this needs to be after the apis
+import numpy as np
+import pytest
+
+from klr import Kernel
+
+# Success cases
+# (these functions should load and trace to KLR)
+
+def pointers():
+  x = sbuf[0:128, 0:512]
+  y = x[32:,:]
+  a = pmem[:64,:512]
+  b = a[32:,:]
+  sb = sbuf[:,1024:2048]
+  left = sb[:,0:512]
+  right = sb[:,512:]
+  big = sbuf[None,:]
+
+# test each function in turn
+@pytest.mark.parametrize("f", [
+  pointers,
+  ])
+def test_succeed(f):
+  F = Kernel(f)   # parse python
+  file = F()      # specialize, and reduce to KLR
+  os.remove(file)
+
+# Failing cases
+# (These functions are expected to fail elaboration to KLR)
+
+def bad_pointer1(): sbuf[1:,0:512]   # sbuf must start at 0,32,64, or 96
+def bad_pointer2(): sbuf[0:32,5:32]  # starts must be even
+def bad_pointer3(): sbuf[None,0:511] # ends must be even
+def bad_pointer4(): sbuf[None,0:0x50000] # too big free dim
+def bad_pointer5(): sbuf[0:130,0:512] # too big pdim
+
+@pytest.mark.parametrize("f", [
+  bad_pointer1,
+  bad_pointer2,
+  bad_pointer3,
+  bad_pointer4,
+  bad_pointer5,
+])
+def test_fails(f):
+  F = Kernel(f)
+  with pytest.raises(Exception):
+    F()


### PR DESCRIPTION
This is the first part of the implementation for the new allocation API in NKI. This new API allows users to create memory regions, and then attach tensors to these regions. This change introduces memory regions; attaching tensors will be done in a follow up change.