### PR TITLE
chore: bump version number to v0.0.9

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -328,7 +328,7 @@ def nkiToKLRCmd := `[Cli|
 ]
 
 def klrCmd : Cmd := `[Cli|
-  klr NOOP; ["0.0.8"]
+  klr NOOP; ["0.0.9"]
   "KLR is an IR for NKI and other tensor-like languages in Lean."
 
   SUBCOMMANDS:

--- a/interop/pyproject.toml
+++ b/interop/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "klr-lang"
-version = "0.0.8"
+version = "0.0.9"
 authors = [
   {name = "Paul Govereau", email = "govereau@amazon.com"},
   {name = "Sean McLaughlin", email = "seanmcl@amazon.com"},


### PR DESCRIPTION
It seems like good practice to bump the version right after a release.