### PR TITLE
feat: add invariants to Core types

### DIFF
--- a/KLR/BIR/Compile/Memory.lean
+++ b/KLR/BIR/Compile/Memory.lean
@@ -91,10 +91,10 @@ def accessToAP : Access -> Compile PhysicalAccessPattern
   | .simple t@{ shape := ⟨ a, [b] ⟩, .. } => do
       let ap <- dimToAP a b
       return (setMemRef t ap)
-  | .basic t@{ shape := ⟨ a, [b] ⟩, ..} ix _ => do
-      let ap <- slicesToAP a b ix
+  | .basic { tensor := t@{ shape := ⟨ a, [b] ⟩, ..} , indexes, .. } => do
+      let ap <- slicesToAP a b indexes
       return (setMemRef t ap)
-  | .pattern t ap => do
-      let ap := pairsToAP ap.offset (⟨1, ap.parNum⟩ :: ap.freePattern )
-      return (setMemRef t ap)
+  | .pattern ap => do
+      let ap' := pairsToAP ap.offset (⟨1, ap.parNum⟩ :: ap.freePattern )
+      return (setMemRef ap.tensor ap')
   | _ => throw "unsupported access"

--- a/KLR/Core/Pretty.lean
+++ b/KLR/Core/Pretty.lean
@@ -55,18 +55,21 @@ instance : ToFormat Index where
   | .coord i => format i
   | .slice l u s => .joinSep [format l, format u, format s] ":"
 
+instance : ToFormat AccessBasic where
+  format acc := format acc.tensor ++ sqArgs acc.indexes
+
 instance : ToFormat APPair where
   format ap := args [ap.step, Int.ofNat ap.num]
 
 instance : ToFormat AccessPattern where
-  format ap := .sbracket <| sqArgs <|
-    format ap.offset :: format ap.parNum :: ap.freePattern.map format
+  format ap := format ap.tensor ++ (.sbracket <| sqArgs <|
+    format ap.offset :: format ap.parNum :: ap.freePattern.map format)
 
 instance : ToFormat Access where
   format
   | .simple t => format t
-  | .basic t l _ => format t ++ sqArgs l
-  | .pattern t ap => format t ++ format ap
+  | .basic acc => format acc
+  | .pattern ap => format ap
 
 instance : ToFormat Operator where
   format

--- a/KLR/Trace/Python.lean
+++ b/KLR/Trace/Python.lean
@@ -382,7 +382,7 @@ partial def expr' : Expr' -> Trace Term
       let shape <- Core.Shape.fromList shape
       let name <- genName "t".toName
       let dtype <- fromNKI? (.expr (.value $ .var dty) .none)
-      let tensor := { name := name.toString, dtype, shape }
+      let tensor <- Core.TensorName.make name.toString dtype shape none
       return .expr (.value $ .access $ .simple tensor) (.tensor dtype shape)
   | .name id _ => lookup id.toName
   | .attr e id _ => do ((<- expr e : Term).attr id)
@@ -498,8 +498,8 @@ where
   | other => return other
   renameAcc (s : String) : Core.Access -> Err Core.Access
   | .simple t => return .simple (renameTN s t)
-  | .basic t l _ => Core.Access.mkBasic (renameTN s t) l
-  | .pattern t ap => return .pattern (renameTN s t) ap
+  | .basic { tensor, indexes, .. } => Core.Access.mkBasic (renameTN s tensor) indexes
+  | .pattern ap => return .pattern { ap with tensor := renameTN s ap.tensor }
   renameTN (s : String) (t : Core.TensorName) : Core.TensorName := { t with name := s }
 
 /-

--- a/KLR/Trace/Types.lean
+++ b/KLR/Trace/Types.lean
@@ -133,24 +133,6 @@ instance : Inhabited Term where
 
 namespace Term
 
-def type : Term -> TermType
-  | .module name => .obj name
-  | .builtin _ t _ => t
-  | .source _    => .obj (.mkStr1 "function")
-  | .none        => .none
-  | .string _    => .string
-  | .tuple l     => .tuple (types l)
-  | .list l      => .list (types l)
-  | .ellipsis    => .obj (.mkStr1 "ellipsis")
-  | .slice ..    => .obj (.mkStr1 "slice")
-  | .store a ..  => .tensor a.tensor.dtype a.shape
-  | .pointer ..  => .obj (.mkStr1 "pointer")
-  | .expr _ t    => t
-where
-  types : List Term -> List TermType
-  | [] => []
-  | x :: xs => type x :: types xs
-
 -- TODO: not efficient!
 -- TODO: this is partial because of the use of flatMap
 -- the ▷ syntax in Util could be updated to handle this case.


### PR DESCRIPTION
This changes adds invariants, in the form of proof terms, to several of the Core types. Once the types are constructed, the invariants can be relied upon. As a general rule, we do not use the invariants directly in code that we want to prove things about, to avoid dependent pattern matching.  Rather, we use an error monad and then prove a theorem that guarantees the computation will not fail by using the invariants.