### PR TITLE
chore: remove the triangle notation

### DIFF
--- a/KLR/BIR/Compile/Kernel.lean
+++ b/KLR/BIR/Compile/Kernel.lean
@@ -37,7 +37,7 @@ def compile_kernel (k : Kernel) : Compile BIR := do
   let outputs <- k.outputs.mapM (allocate .Output)
   let internal <- k.internal.mapM (allocate .Internal)
   let allocs := inputs ++ outputs ++ internal
-  let insts <- compileStmt ▷ k.body
+  let insts <- k.body.mapM compileStmt
   -- There is always one function with one block...
   return {
     functions := [{

--- a/KLR/Trace/FromNKI.lean
+++ b/KLR/Trace/FromNKI.lean
@@ -28,7 +28,7 @@ def fromNKI [FromNKI a] (dflt : a) (t : Term) : a :=
 
 instance [FromNKI a] : FromNKI (List a) where
   fromNKI?
-  | .tuple l | .list l => fromNKI? ▷ l
+  | .tuple l | .list l => l.mapM fromNKI?
   | _ => throw "expecting sequence (list or tuple)"
 
 instance [FromNKI a] : FromNKI (Option a) where

--- a/KLR/Util.lean
+++ b/KLR/Util.lean
@@ -27,23 +27,6 @@ The default choice for a state monad is `EStateM String`.
 -/
 abbrev StM := EStateM String
 
-/-
-A common issue is failure to prove termination automatically when using
-List.mapM. There is a work-around for this which involves introducing
-`{ x // x ∈ l }` in place of the list `l`.
-
-We can capture this trick in a notation. Note we need to use a notation and not
-a definition because the proof object `x∈l` needs to be available to the
-termination proof tactics, in the scope of the original function.
-
-Writing, `List.mapM f l`, as `f ▷ l` doesn't break the termination proof.
-Note: ▷ is typed as \rhd
-TODO: This notation doesn't work outside of a Monad
-TODO: Choose a non-unicode character
--/
-notation f "▷" l =>
-  List.mapM (fun ⟨ x, _ ⟩ => f x) (List.attach l)
-
 def impossible {a : Type} [h : Inhabited a] (msg : String := "") :=
   @panic a h s!"Invariant violation: {msg}"
 


### PR DESCRIPTION
The triangle notation was introduced to get around a limitation in Lean that couldn't prove termination when mapM was used, even if it was structurally
obvious. I didn't like the notation solution because it seemed brittle; I tried replacing the notation with a def and an abbrev, but neither worked. I still don't understand why it works, but I also don't understand why

    | .tuple es .store => return .tuple (<- es.attach.mapM fun ⟨ e, _ ⟩ => LValue e)

works but

    | .tuple es .store => return .tuple (<- es.attach.mapM fun e => LValue e.val)

does not. Since this is now required in only 2 spots (thanks likely to improvements in Lean itself) I propose we just remove the notation and do the trick until it's no longer needed.