### PR TITLE
refactor: make Python AST more amenable to extraction to C

### DIFF
--- a/KLR/Trace/Basic.lean
+++ b/KLR/Trace/Basic.lean
@@ -83,8 +83,8 @@ where
     | [x] => return x
     | x :: xs => do if (<- fn x) then return x else bop fn xs
   bopFn : BoolOp -> Err (Term -> Err Bool)
-    | .or  => return Term.isTrue
-    | .and => return Term.isFalse
+    | .lor  => return Term.isTrue
+    | .land => return Term.isFalse
 
 -- Binary Operators
 
@@ -238,7 +238,7 @@ def cmpOp : CmpOp -> Term -> Term -> Trace Bool
   | .notIn, l, r => return not (<- termIn l r)
 
 -- Python comparison chains are short-circuting
--- e.g. x < y < z  => x < y || y < z
+-- e.g. x < y < z  => x < y && y < z
 def compare : Term -> List CmpOp -> List Term -> Trace Term
   | x, [op], [y] => return bool (<- cmpOp op x y)
   | x, op::ops, y::ys => do

--- a/Main.lean
+++ b/Main.lean
@@ -161,11 +161,11 @@ def parseAST (p : Parsed) : IO UInt32 := do
     IO.println s!"{repr kernel}"
     return 0
   IO.println s!"AST summary for kernel {kernel.entry}"
-  let fs := String.intercalate "," $ kernel.funcs.map Prod.fst
+  let fs := String.intercalate "," $ kernel.funcs.map fun f => f.name
   IO.println s!"Source Functions: {fs}"
-  let gs := String.intercalate "," $ kernel.globals.map Prod.fst
+  let gs := String.intercalate "," $ kernel.globals.map fun kw => kw.id
   IO.println s!"Globals: {gs}"
-  IO.println s!"Undefined names {kernel.undefinedSymbols.toList.mergeSort}"
+  IO.println s!"Undefined names {kernel.undefinedSymbols.mergeSort}"
   return 0
 
 def trace (p : Parsed) : IO UInt32 := do


### PR DESCRIPTION
Small modifications to Python AST to make it easier to automatically generate equivalent C and Python versions. Changes include: replacing single constructor inductive types with structures, replacing Prod types with structures, renaming some constructors to avoid conflicts, replacing HashSet with List.