### PR TITLE
feat: introduce NKI abstract syntax

### DIFF
--- a/KLR.lean
+++ b/KLR.lean
@@ -6,5 +6,6 @@ Authors: Paul Govereau, Sean McLaughlin
 import KLR.BIR
 import KLR.Core
 import KLR.Eval
+import KLR.NKI
 import KLR.Python
 import KLR.Trace

--- a/KLR/NKI.lean
+++ b/KLR/NKI.lean
@@ -1,0 +1,6 @@
+/-
+Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+import KLR.NKI.Basic

--- a/KLR/NKI/Basic.lean
+++ b/KLR/NKI/Basic.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+
+/-!
+# Abstract syntax of NKI functions
+
+This AST is produced from the Python AST by simplification.
+The two ASTs are similar. This one is the "official" abstract
+syntax of NKI.
+-/
+
+namespace KLR.NKI
+
+structure Pos where
+  line : Nat
+  column : Nat
+  deriving Repr
+
+-- Note: the python int and float types are compatible with Lean's types
+-- The str type may require conversion (to UTF8).
+inductive Value where
+  | none
+  | bool (value : Bool)
+  | int (value : Int)
+  | float (value : Float)
+  | string (value : String)
+  | ellipsis
+  | tensor (shape : List Nat) (dtype : String)  -- TODO use Core Dtype
+  deriving Repr
+
+inductive BinOp where
+  -- logical
+  | land | lor
+  -- comparison
+  | eq | ne | lt | le | gt | ge
+  -- arithmetic
+  | add | sub | mul | div | mod | pow | floor
+  -- bitwise
+  | lshift | rshift | or | xor | and
+  deriving Repr
+
+mutual
+structure Expr where
+  expr : Expr'
+  pos : Pos
+  deriving Repr
+
+inductive Expr' where
+  | value (value : Value)
+  | var (name : String)
+  | proj (expr : Expr) (name : String)
+  | tuple (elements : List Expr)
+  | access (expr : Expr) (indices : List Index)
+  | binOp (op : BinOp) (left right : Expr)
+  | ifExp (test body orelse : Expr)
+  | call (f: Expr) (args: List Expr) (keywords : List Keyword)
+  deriving Repr
+
+inductive Index where
+  | coord (i : Expr)
+  | slice (l u step : Option Expr)
+  deriving Repr
+
+structure Keyword where
+  name : String
+  expr : Expr
+  deriving Repr
+end
+
+mutual
+structure Stmt where
+  stmt : Stmt'
+  pos : Pos
+  deriving Repr
+
+inductive Stmt' where
+  | expr (e : Expr)
+  | assert (e : Expr)
+  | ret (e : Expr)
+  | assign (x : Expr) (ty e : Option Expr)
+  | ifStm (e : Expr) (thn els: List Stmt)
+  | forLoop (x : Expr) (iter: Expr) (body: List Stmt)
+  | breakLoop
+  | continueLoop
+  deriving Repr
+end
+
+structure Param where
+  name : String
+  default : Option Expr
+  deriving Repr
+
+structure Fun where
+  name : String
+  file : String
+  line : Nat
+  body : List Stmt
+  args : List Param
+  deriving Repr
+
+structure Arg where
+  name : String
+  value : Expr
+  deriving Repr
+
+structure Kernel where
+  entry : String
+  funs : List Fun
+  args : List Arg
+  globals : List Arg
+  deriving Repr

--- a/KLR/Python.lean
+++ b/KLR/Python.lean
@@ -78,6 +78,7 @@ structure Expr where
 
 inductive Expr' where
   | const (value : Const)
+    -- TODO we don't need tensor here, it can be NKI only
   | tensor (shape : List Expr) (dtype : String)
   | name (id : String) (ctx : Ctx)
   | attr (value : Expr) (id : String) (ctx : Ctx)
@@ -110,8 +111,8 @@ inductive Stmt' where
   | pass
   | expr (e : Expr)
   | assert (e : Expr)
-  | ret (e: Expr)
-  | assign (xs: List Expr) (e: Expr)
+  | ret (e : Expr)
+  | assign (xs : List Expr) (e: Expr)
   | augAssign (x : Expr) (op : BinOp) (e : Expr)
   | annAssign (x : Expr) (annotation : Expr) (value : Option Expr)
   | ifStm (e : Expr) (thn els: List Stmt)


### PR DESCRIPTION
This change introduces the abstract syntax of NKI.  This change is part of a larger effort to break KLR up into smaller passes that can be more easily compared with the upcoming C++ implementation. The first of these passes will be a simplification pass that consumes the Python Core AST and produces the NKI AST (contained in this patch).