### PR TITLE
feat: Add simple libarchive (aka "tar") interface to Lean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install libz on Ubuntu
+      - name: Install C libraries on Ubuntu
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev
+        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev libarchive-dev
 
-      - name: Install libz on macOS
+      - name: Install C libraries on macOS
         if: startsWith(matrix.os, 'macos')
-        run: brew install zlib
+        run: brew install zlib libarchive
 
       - uses: leanprover/lean-action@v1
         with:

--- a/KLR/Util/Archive.lean
+++ b/KLR/Util/Archive.lean
@@ -1,0 +1,7 @@
+/-
+Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+
+import KLR.Util.Archive.Archive

--- a/KLR/Util/Archive/Archive.lean
+++ b/KLR/Util/Archive/Archive.lean
@@ -1,0 +1,20 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+
+namespace Util
+
+structure ArchiveEntry where
+  filename : String
+  content : ByteArray
+  deriving Inhabited
+
+@[extern "lean_archive_create_tar"]
+opaque createTar (entries : @&List ArchiveEntry) : ByteArray
+
+@[extern "lean_archive_extract_tar"]
+opaque extractTar (bytes : @&ByteArray) : List ArchiveEntry
+
+end Util

--- a/KLR/Util/Archive/Main.lean
+++ b/KLR/Util/Archive/Main.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+
+import Archive
+import Cli
+
+open Cli
+open System(FilePath)
+open Util
+
+def create (p : Parsed) : IO UInt32 := do
+  let files := p.variableArgsAs! String
+  let outfile := p.flag! "output" |>.as! String
+  let mut entries := []
+  for file in files do
+    if <- FilePath.pathExists file then
+      let contents <- IO.FS.readBinFile file
+      let entry := ArchiveEntry.mk file contents
+      entries := entry :: entries
+    else
+      IO.eprintln s!"File doesn't exist: {file}"
+      return 1
+  let tarBytes := createTar entries
+  IO.FS.writeBinFile outfile tarBytes
+  IO.println s!"Wrote tar archive to {outfile} ({tarBytes.size} bytes)"
+  return 0
+
+def cwd : IO FilePath := IO.FS.realPath "."
+
+def extract (p : Parsed) : IO UInt32 := do
+  let input := p.positionalArg! "input" |>.as! String
+  let tarBytes <- IO.FS.readBinFile input
+  let entries := extractTar tarBytes
+  IO.println s!"Extracted {entries.length} files from archive:"
+  let dir <-
+    if p.hasFlag "dir" then
+      pure $ FilePath.mk (p.flag! "dir" |>.as! String)
+    else
+      cwd
+  for entry in entries do
+    IO.println s!"File: {entry.filename}"
+    let path := System.FilePath.join dir entry.filename
+    match System.FilePath.parent path with
+    | some parent => IO.FS.createDirAll parent
+    | none => pure ()
+    IO.FS.writeBinFile path entry.content
+    IO.println s!"  Extracted to {path}"
+  return 0
+
+def createCmd : Cmd := `[Cli|
+  create VIA create; ["0.0.1"]
+  "Create a tar archive from files"
+
+  FLAGS:
+    o, output : String; "output tar file"
+
+  ARGS:
+    ...files : String; "input file paths"
+]
+
+def extractCmd : Cmd := `[Cli|
+  extract VIA extract; ["0.0.1"]
+  "Extract files from a tar archive"
+
+  FLAGS:
+    C, dir : String; "directory to extract files to (default is cwd)"
+
+  ARGS:
+    input : String; "input tar file"
+]
+
+def archiveCmd : Cmd := `[Cli|
+  archive VIA (fun _ => pure 0); ["0.0.1"]
+  "Work with tar archives"
+
+  SUBCOMMANDS:
+    createCmd;
+    extractCmd
+]
+
+def main (args : List String) : IO UInt32 :=
+  if args.isEmpty then do
+    IO.println archiveCmd.help
+    return 0
+  else
+    archiveCmd.validate args

--- a/KLR/Util/Archive/bin/tar
+++ b/KLR/Util/Archive/bin/tar
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+ROOT=$(dirname $(dirname $(readlink -f $0)))
+
+$ROOT/.lake/build/bin/archive $@

--- a/KLR/Util/Archive/lake-manifest.json
+++ b/KLR/Util/Archive/lake-manifest.json
@@ -1,0 +1,15 @@
+{"version": "1.1.0",
+ "packagesDir": ".lake/packages",
+ "packages":
+ [{"url": "https://github.com/leanprover/lean4-cli.git",
+   "type": "git",
+   "subDir": null,
+   "scope": "",
+   "rev": "7cde559c7e6541d964984bff81caca3fe4e763a6",
+   "name": "Cli",
+   "manifestFile": "lake-manifest.json",
+   "inputRev": "v4.18.0",
+   "inherited": false,
+   "configFile": "lakefile.toml"}],
+ "name": "Archive",
+ "lakeDir": ".lake"}

--- a/KLR/Util/Archive/lakefile.lean
+++ b/KLR/Util/Archive/lakefile.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+
+import Lake
+open Lake DSL
+open System(FilePath)
+
+package Archive where
+
+def noStackProtector := "-fno-stack-protector"
+
+def moreLinkArgs :=
+  let all := #["-larchive"]
+  if System.Platform.isOSX then
+    all ++ #[
+      "-L/opt/homebrew/opt/libarchive/lib",
+      "-L/usr/local/opt/libarchive/lib"
+    ]
+  else
+    -- TODO: figure out how to properly compile/link with ssp turned on
+    all ++ #[
+      noStackProtector
+    ]
+
+def moreWeakArgs :=
+  let all := #[]
+  if System.Platform.isOSX then
+    all ++ #[
+      "-I", "/opt/homebrew/opt/libarchive/include",
+      "-I", "/usr/local/opt/libarchive/include"
+    ]
+  else
+    all ++ #[
+      noStackProtector
+    ]
+
+@[default_target]
+lean_lib Archive where
+  moreLinkArgs := moreLinkArgs
+
+@[default_target]
+lean_exe archive where
+  moreLinkArgs := moreLinkArgs
+  root := `Main
+
+target lean_archive.o pkg : FilePath := do
+  let oFile := pkg.buildDir / "lean_archive.o"
+  let srcJob ← inputTextFile <| pkg.dir / "lean_archive.c"
+  let weakArgs := #["-I", (← getLeanIncludeDir).toString] ++ moreWeakArgs
+  let compilerFlags := #["-fPIC", "-Werror"]
+  buildO oFile srcJob weakArgs compilerFlags "cc" getLeanTrace
+
+extern_lib liblean_archive pkg := do
+  let ffiO ← lean_archive.o.fetch
+  let name := nameToStaticLib "lean_archive"
+  buildStaticLib (pkg.nativeLibDir / name) #[ffiO]
+
+require Cli from git
+  "https://github.com/leanprover/lean4-cli.git" @ "v4.18.0"

--- a/KLR/Util/Archive/lean-toolchain
+++ b/KLR/Util/Archive/lean-toolchain
@@ -1,0 +1,1 @@
+../../../lean-toolchain

--- a/KLR/Util/Archive/lean_archive.c
+++ b/KLR/Util/Archive/lean_archive.c
@@ -1,0 +1,193 @@
+/*
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+*/
+
+#define _GNU_SOURCE // for vasprintf
+
+#include <lean/lean.h>
+#include <stdarg.h>
+#include <string.h>
+#include <archive.h>
+#include <archive_entry.h>
+
+lean_object* io_err(const char* fmt, ...) {
+  char* msg = NULL;
+  va_list args;
+  va_start(args, fmt);
+  const int bytes = vasprintf(&msg, fmt, args);
+  va_end(args);
+  lean_object *lean_msg;
+  if (bytes < 0) {
+    fprintf(stderr, "couldn't format error message: %s", fmt);
+    lean_msg = lean_mk_string(fmt);
+  } else {
+    lean_msg = lean_mk_string(msg); // copies
+    free(msg);
+  }
+  return lean_io_result_mk_error(lean_mk_io_user_error(lean_msg));
+}
+
+lean_object* create_archive_entry(const char* filename, uint8_t* data, size_t size) {
+  lean_object* entry = lean_alloc_ctor(0, 2, 0);
+  lean_object* lean_filename = lean_mk_string(filename);
+  lean_object* lean_content = lean_alloc_sarray(1, size, size);
+  memcpy(lean_sarray_cptr(lean_content), data, size);
+  
+  lean_ctor_set(entry, 0, lean_filename);
+  lean_ctor_set(entry, 1, lean_content);
+  
+  return entry;
+}
+
+// Create a tar archive from a list of file entries
+LEAN_EXPORT lean_object* lean_archive_create_tar(lean_object* entries) {
+  struct archive* a;
+  struct archive_entry* entry;
+  char* buff;
+  size_t buffsize = 65536;
+  size_t used = 0;
+  int r;
+
+  buff = (char*)malloc(buffsize);
+  if (buff == NULL) {
+    return io_err("Failed to allocate memory for archive buffer");
+  }
+
+  a = archive_write_new();
+  archive_write_set_format_pax_restricted(a); // Use tar format
+  archive_write_open_memory(a, buff, buffsize, &used);
+
+  lean_object* curr = entries;
+  while (!lean_is_scalar(curr)) {
+    lean_object* head = lean_ctor_get(curr, 0);
+    curr = lean_ctor_get(curr, 1);
+
+    lean_object* filename_obj = lean_ctor_get(head, 0);
+    const char* filename = lean_string_cstr(filename_obj);
+    
+    lean_object* content_obj = lean_ctor_get(head, 1);
+    size_t content_size = lean_sarray_size(content_obj);
+    uint8_t* content = lean_sarray_cptr(content_obj);
+        
+    entry = archive_entry_new();
+    archive_entry_set_pathname(entry, filename);
+    archive_entry_set_size(entry, content_size);
+    archive_entry_set_filetype(entry, AE_IFREG);
+    archive_entry_set_perm(entry, 0644);
+    
+    r = archive_write_header(a, entry);
+    if (r != ARCHIVE_OK) {
+      archive_entry_free(entry);
+      archive_write_free(a);
+      free(buff);
+      return io_err("Failed to write archive header: %s", archive_error_string(a));
+    }
+    
+    r = archive_write_data(a, content, content_size);
+    if (r < 0) {
+      archive_entry_free(entry);
+      archive_write_free(a);
+      free(buff);
+      return io_err("Failed to write archive data: %s", archive_error_string(a));
+    }
+    
+    archive_entry_free(entry);
+  }
+  
+  r = archive_write_close(a);
+  if (r != ARCHIVE_OK) {
+    archive_write_free(a);
+    free(buff);
+    return io_err("Failed to close archive: %s", archive_error_string(a));
+  }
+  
+  r = archive_write_free(a);
+  if (r != ARCHIVE_OK) {
+    free(buff);
+    return io_err("Failed to free archive: %s", archive_error_string(a));
+  }
+  
+  lean_object* result = lean_alloc_sarray(1, used, used);
+  memcpy(lean_sarray_cptr(result), buff, used);
+  
+  free(buff);
+  return result;
+}
+
+LEAN_EXPORT lean_object* lean_archive_extract_tar(lean_object* bytes) {
+  struct archive* a;
+  struct archive_entry* entry;
+  int r;
+  
+  uint8_t* data = lean_sarray_cptr(bytes);
+  size_t size = lean_sarray_size(bytes);
+  
+  a = archive_read_new();
+  archive_read_support_format_all(a);
+  archive_read_support_filter_all(a);
+  
+  r = archive_read_open_memory(a, data, size);
+  if (r != ARCHIVE_OK) {
+    archive_read_free(a);
+    return io_err("Failed to open archive: %s", archive_error_string(a));
+  }
+  
+  lean_object* result = lean_box(0); // Empty list
+  
+  while (archive_read_next_header(a, &entry) == ARCHIVE_OK) {
+    const char* pathname = archive_entry_pathname(entry);
+    size_t entry_size = archive_entry_size(entry);
+    
+    // Skip directories
+    if (archive_entry_filetype(entry) != AE_IFREG) {
+      archive_read_data_skip(a);
+      continue;
+    }
+    
+    uint8_t* file_data = (uint8_t*)malloc(entry_size);
+    if (file_data == NULL) {
+      archive_read_free(a);
+      return io_err("Failed to allocate memory for file data");
+    }
+    
+    size_t bytes_read = archive_read_data(a, file_data, entry_size);
+    if (bytes_read != entry_size) {
+      free(file_data);
+      archive_read_free(a);
+      return io_err("Failed to read file data: %s", archive_error_string(a));
+    }
+    
+    lean_object* archive_entry_obj = create_archive_entry(pathname, file_data, entry_size);
+    free(file_data);
+    
+    lean_object* new_cell = lean_alloc_ctor(1, 2, 0);
+    lean_ctor_set(new_cell, 0, archive_entry_obj);
+    lean_ctor_set(new_cell, 1, result);
+    result = new_cell;
+  }
+  
+  r = archive_read_free(a);
+  if (r != ARCHIVE_OK) {
+    return io_err("Failed to free archive: %s", archive_error_string(a));
+  }
+  
+  // Reverse the list to maintain original order
+  lean_object* reversed = lean_box(0); 
+  lean_object* curr = result;
+  
+  while (!lean_is_scalar(curr)) {
+    lean_object* head = lean_ctor_get(curr, 0);
+    lean_object* tail = lean_ctor_get(curr, 1);
+    
+    lean_object* new_cell = lean_alloc_ctor(1, 2, 0);
+    lean_ctor_set(new_cell, 0, head);
+    lean_ctor_set(new_cell, 1, reversed);
+    
+    reversed = new_cell;
+    curr = tail;
+  }
+  
+  return reversed;
+}

--- a/KLR/Util/Gzip/bin/gzip
+++ b/KLR/Util/Gzip/bin/gzip
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+ROOT=$(dirname $(dirname $(readlink -f $0)))
+
+$ROOT/.lake/build/bin/gzip $@


### PR DESCRIPTION
Note how this creates/extracts in `ByteArray`s so we can take a Lean data structure representing the NEFF, convert the files to `ByteArray`s, create the archive, gzip it, plop the NEFF header on and write to disk. 