### PR TITLE
feat: add serde attribute for defining serialized formats

### DIFF
--- a/KLR.lean
+++ b/KLR.lean
@@ -9,5 +9,6 @@ import KLR.Eval
 import KLR.NEFF
 import KLR.NKI
 import KLR.Python
+import KLR.Serde
 import KLR.Trace
 import KLR.Util

--- a/KLR/Serde.lean
+++ b/KLR/Serde.lean
@@ -1,0 +1,7 @@
+/-
+Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+import KLR.Serde.Attr
+import KLR.Serde.Test

--- a/KLR/Serde/Attr.lean
+++ b/KLR/Serde/Attr.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+import Lean
+
+/-
+# Attribute for serialization and de-serialization
+
+This modules defines a new attribute and some meta-programming utilities for
+accessing the attribute data. Note: new attributes must be defined in a
+separate module from where they are used. See `Test.lean` for more details.
+-/
+namespace KLR.Serde
+open Lean Meta
+
+private structure SerdeTag where
+  tag : Nat
+  deriving Inhabited, BEq, Repr
+
+syntax (name := serde) "serde" "tag" "=" num : attr
+
+private initialize tags : ParametricAttribute SerdeTag <-
+  registerParametricAttribute {
+    name := `serde
+    descr := "Assign Serde tag"
+    getParam name stx := do
+      let `(attr| serde tag = $t:num  ) := stx
+        | throwError "invalid [serde] attribute"
+      return ⟨ TSyntax.getNat t ⟩
+  }
+
+-- Return the serde tag for a name (if any)
+def serdeTag [Monad m] [MonadEnv m] (name : Name) : m (Option Nat) := do
+  return (tags.getParam? (<- getEnv) name).map (·.tag)
+
+-- Check for duplicates and reverse list (private function used below)
+private def checkDups (l : List (a × Nat)) : MetaM (List (a × Nat)) := do
+  let rec loop l1 l2 :=
+    match l1, l2 with
+    | l1, [] => return l1
+    | l1, x :: xs =>
+      if l1.any fun p => p.2 == x.2
+      then throwError s!"duplicate Serde tag found {x.2}"
+      else loop (x :: l1) xs
+  loop [] l
+
+/-
+Return a mapping of constructor names to serde tags for a given type. Any
+constructors without assigned tags will be automatically assigned a tag
+starting equal to the previous tag plus one, while avoiding any user defined
+values.
+
+One important use case is adding a new constructor. If we add a new constructor
+to a type, but we don't want to add it at the end, then we can manually assign
+it a tag and the other constructors will end up with their previous assignments.
+
+inductive A | a | c | d
+-- mapping is a=0, c=1, d=2
+
+-- changed to:
+inductive A | a | b | c | d
+-- mapping is: a=0, b=1, c=2, d=3  (INCORRECT)
+
+@[serde tag = 3 ] A.b
+-- mapping is: a=0, b=3, c=1, d=2  (correct)
+
+See Test.lean for more details.
+-/
+partial def nextTag (user : List (Option Nat)) (n : Nat) : Nat :=
+  let n := n + 1
+  if user.contains (some n)
+  then nextTag user n
+  else n
+
+def serdeMap (name : Name) : MetaM (List (Name × Nat)) := do
+  let tcs <- getConstInfoInduct name
+  let user <- tcs.ctors.mapM serdeTag
+  let nextTag := nextTag user
+  let mut current := 0
+  let mut res := []
+  for ctor in tcs.ctors do
+    match <- serdeTag ctor with
+    | none =>
+        res := (ctor, current) :: res
+        current := nextTag current
+    | some n =>
+        res := (ctor, n) :: res
+        current := nextTag n
+  checkDups res
+
+-- Convenience function: serdeTag and serdeMap
+def serdeTags (name : Name) : MetaM (Nat × List (Name × Nat)) := do
+  match <- serdeTag name with
+  | none => throwError s!"No serde tags for {name}"
+  | some t => return (t, <- serdeMap name)

--- a/KLR/Serde/Test.lean
+++ b/KLR/Serde/Test.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+import KLR.Serde.Attr
+import Lean
+
+/-
+Tests for the serde attribute.
+
+New attributes must be defined in a separate module from where they are used.
+This module has some basic compile-time tests and documentation for the Attr
+module.
+-/
+
+namespace KLR.Serde.Test
+
+/-
+The serde attribute allows you to associate a natural number with a type or
+value constructor. The main motivation for this is to support serialization and
+de-serialization.
+
+For example, we can assign a tag to the inductive type `Foo`.
+-/
+
+@[serde tag = 3]
+inductive Foo where
+  | a : Int -> Foo
+  | b : Float -> Foo
+
+/-
+Then, from a meta-program we can query this value
+-/
+
+/-- info: some 3 -/
+#guard_msgs in #eval serdeTag ``Foo
+
+/-
+You can also assign tags to value constructors, and query these values from
+meta-programs. Any value constructors without assigned tags will return `none`
+if queried.
+-/
+
+attribute [serde tag = 4] Foo.a
+
+/-- info: some 4 -/
+#guard_msgs in #eval serdeTag ``Foo.a
+
+/-- info: none -/
+#guard_msgs in #eval serdeTag ``Foo.b
+
+/-
+The `serdeMap` function will return a mapping of all the values constructors
+for a type and their associated tags. This function will automatically assign
+tags to any constructors that do not have one assigned. This works similar to C
+enums: if a constructor doesn't have a tag, it is assigned to be the previous
+constructor's tag plus one. Numbering starts at zero.
+-/
+
+/-- info: [(`KLR.Serde.Test.Foo.a, 4), (`KLR.Serde.Test.Foo.b, 5)] -/
+#guard_msgs in#eval serdeMap ``Foo
+
+/-
+The serde tags can be assigned (or reassigned) away from the type definition.
+-/
+
+attribute [serde tag = 11] Foo
+attribute [serde tag = 7] Foo.a
+attribute [serde tag = 3] Foo.b
+
+/-- info: some 11 -/
+#guard_msgs in #eval serdeTag ``Foo
+
+/-- info: some 7 -/
+#guard_msgs in #eval serdeTag ``Foo.a
+
+/-- info: some 3 -/
+#guard_msgs in #eval serdeTag ``Foo.b
+
+/-
+For convenience, the `serdeTags` function returns all of the data for a given type.
+-/
+
+/-- info: (11, [(`KLR.Serde.Test.Foo.a, 7), (`KLR.Serde.Test.Foo.b, 3)]) -/
+#guard_msgs in #eval serdeTags ``Foo
+
+/-
+All of these things can also be used on structures, although the map of value
+constructors is less useful.
+-/
+
+@[serde tag = 1]
+structure Bar where
+  x : Int
+  y : Int
+
+/-- info: (1, [(`KLR.Serde.Test.Bar.mk, 0)]) -/
+#guard_msgs in #eval serdeTags ``Bar
+
+
+/-
+While not the main motivation, `serdeMap` can be used on any lean type to get
+the Lean constructor numbers: the numbering used by `serdeMap` is compatible
+with how Lean numbers constructors internally. This may be useful for C code
+that needs to work with Lean values. Foe example, we can calculate what the
+first argument of `lean_alloc_ctor` should be for the `Lean.Name` type.
+-/
+
+/-- info:
+#define Lean_Name_anonymous 0
+#define Lean_Name_str 1
+#define Lean_Name_num 2
+-/
+#guard_msgs in #eval do
+  for (n,v) in <- serdeMap ``Lean.Name do
+    let n := n.toString.replace "." "_"
+    IO.println s!"#define {n} {v}"


### PR DESCRIPTION
This changes add a new attribute for constructors: "serde tag=n".  The motivation is to provide an easy way to define how constructors should be mapped to numeric values in serialized formats.