### PR TITLE
chore: fix the type of allocated in BIR.MemoryLocation to Bool

### DIFF
--- a/KLR/BIR/Function.lean
+++ b/KLR/BIR/Function.lean
@@ -113,7 +113,7 @@ structure MemoryLocation where
   dims : List Nat   -- num partitions, bytes per partition
   bank : Nat := 0   -- bank id
   base : Nat := 0   -- base partition (0, 32, 64)
-  allocated : Option Bool := some false
+  allocated : Bool := false
   pinned : Bool := false
   tensor_id : Option Nat := some 0
   deriving BEq, Repr, Lean.FromJson, Lean.ToJson


### PR DESCRIPTION
Currently, `allocated` has a type `Option Bool` in `BIR.MemoryLocation`; it'd be fine to have it just `Bool`, following the type in the compiler.