### PR TITLE
Add attributes for tile_size.* , implement Python floor div

### DIFF
--- a/KLR/Python.lean
+++ b/KLR/Python.lean
@@ -67,7 +67,7 @@ inductive UnaryOp where
 inductive BinOp where
   | add | sub | mul | matmul | div | mod | pow
   | lshift | rshift | or | xor | and
-  | floor
+  | floor -- the '//' operator in Python
   deriving Repr
 
 mutual

--- a/KLR/Trace/NKI.lean
+++ b/KLR/Trace/NKI.lean
@@ -37,6 +37,8 @@ def NKIEnv : List (Name × Term) :=
   , module nki_isa
   , module nki_lang
   , const_int (.str (nl "tile_size") "pmax") 128
+  , const_int (.str (nl "tile_size") "gemm_stationary_fmax") 128
+  , const_int (.str (nl "tile_size") "gemm_moving_fmax") 512
   , const_var (nl "shared_hbm")
   , const_var (nl "private_hbm")
   , const_var (nl "hbm")

--- a/KLR/Trace/Python.lean
+++ b/KLR/Trace/Python.lean
@@ -631,7 +631,7 @@ def termToIter : Term -> Err (List Term)
            then throw "range arg 3 must not be zero"
            else return (range s e t)
        | _ => throw "invalid argument to range"
-  | _ => throw "unsupported loop interator"
+  | _ => throw "unsupported loop iterator"
 
 /-
 # Expressions and Statements

--- a/KLR/Trace/Types.lean
+++ b/KLR/Trace/Types.lean
@@ -179,6 +179,7 @@ structure State where
   locals : Env := ∅
   body : Array Stmt := #[]
   warnings : Array (Pos × String) := #[]
+deriving Repr
 
 instance : Inhabited State where
   default := {}


### PR DESCRIPTION
This patch adds a few more features that are necessary to trace `nki_matmul_tiled_`. I guess each item is worth a small thread of discussion.

1. Add tile_size.gemm_stationary_fmax and tile_size.gemm_moving_fmax: In fact I could not find their concrete values from online. (https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/api/generated/nki.language.tile_size.html did not have the numbers)
Instead. I picked the constants that https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/programming_model.html assume.

2. Expand Term.attr to lookup a local/global variable: This was missing from Term.attr, but I was wondering whether this was intentionally omitted because somewhere in the project I saw that this obj constructor was planned to be removed.

3. Implement Python floor div: I checked that the updated `valueOp` worked by extracting out as a scalar non-monadic function and comparing outputs on random inputs with Python.

```
def python_floordiv (l:Int) (r:Int): Int :=
  if r = 0 then 0 else
  let samesgn := (l < 0) ↔ (r < 0)
  let (l,r) := (l.natAbs, r.natAbs)
  let d := Int.ofNat (l / r)
  (if l % r = 0 then (if samesgn then id else Int.neg) d
    else (if samesgn then d else Int.neg (d + 1)))
 #eval python_floordiv 3 2       -- 1
 #eval python_floordiv 3 (-2)    -- -2
 #eval python_floordiv (-3) 2    -- -2
 #eval python_floordiv (-3) (-2) -- 1
 #eval python_floordiv 4 2       -- 2
 #eval python_floordiv 4 (-2)    -- -2
 #eval python_floordiv (-4) 2    -- -2
 #eval python_floordiv (-4) (-2) -- 2
```