### PR TITLE
chore: use Lean names in C code

### DIFF
--- a/interop/nkic/ast_nki.h
+++ b/interop/nkic/ast_nki.h
@@ -12,13 +12,13 @@ struct NKI_Pos {
 
 struct NKI_Value {
   enum NKI_Value_Tag {
-    NKI_Value_NONE,
-    NKI_Value_BOOL,
-    NKI_Value_INT,
-    NKI_Value_FLOAT,
-    NKI_Value_STRING,
-    NKI_Value_ELLIPSIS,
-    NKI_Value_TENSOR
+    NKI_Value_none,
+    NKI_Value_bool,
+    NKI_Value_int,
+    NKI_Value_float,
+    NKI_Value_string,
+    NKI_Value_ellipsis,
+    NKI_Value_tensor
   } tag;
   union {
     struct NKI_Value_bool {
@@ -41,38 +41,38 @@ struct NKI_Value {
 };
 
 enum NKI_BinOp {
-  NKI_BinOp_Land,
-  NKI_BinOp_Lor,
-  NKI_BinOp_Eq,
-  NKI_BinOp_Ne,
-  NKI_BinOp_Lt,
-  NKI_BinOp_Le,
-  NKI_BinOp_Gt,
-  NKI_BinOp_Ge,
-  NKI_BinOp_Add,
-  NKI_BinOp_Sub,
-  NKI_BinOp_Mul,
-  NKI_BinOp_Div,
-  NKI_BinOp_Mod,
-  NKI_BinOp_Pow,
-  NKI_BinOp_Floor,
-  NKI_BinOp_Lshift,
-  NKI_BinOp_Rshift,
-  NKI_BinOp_Or,
-  NKI_BinOp_Xor,
-  NKI_BinOp_And
+  NKI_BinOp_land,
+  NKI_BinOp_lor,
+  NKI_BinOp_eq,
+  NKI_BinOp_ne,
+  NKI_BinOp_lt,
+  NKI_BinOp_le,
+  NKI_BinOp_gt,
+  NKI_BinOp_ge,
+  NKI_BinOp_add,
+  NKI_BinOp_sub,
+  NKI_BinOp_mul,
+  NKI_BinOp_div,
+  NKI_BinOp_mod,
+  NKI_BinOp_pow,
+  NKI_BinOp_floor,
+  NKI_BinOp_lshift,
+  NKI_BinOp_rshift,
+  NKI_BinOp_or,
+  NKI_BinOp_xor,
+  NKI_BinOp_and
 };
 
 struct NKI_Expr_ {
   enum NKI_Expr_Tag {
-    NKI_Expr_VALUE,
-    NKI_Expr_VAR,
-    NKI_Expr_PROJ,
-    NKI_Expr_TUPLE,
-    NKI_Expr_ACCESS,
-    NKI_Expr_BINOP,
-    NKI_Expr_IFEXP,
-    NKI_Expr_CALL
+    NKI_Expr_value,
+    NKI_Expr_var,
+    NKI_Expr_proj,
+    NKI_Expr_tuple,
+    NKI_Expr_access,
+    NKI_Expr_binOp,
+    NKI_Expr_ifExp,
+    NKI_Expr_call
   } tag;
   union {
     struct NKI_Expr_value {
@@ -116,7 +116,7 @@ struct NKI_Expr {
 };
 
 struct NKI_Index {
-  enum NKI_Index_Tag { NKI_Index_COORD, NKI_Index_SLICE } tag;
+  enum NKI_Index_Tag { NKI_Index_coord, NKI_Index_slice } tag;
   union {
     struct NKI_Index_coord {
       struct NKI_Expr *i;
@@ -136,14 +136,14 @@ struct NKI_Keyword {
 
 struct NKI_Stmt_ {
   enum NKI_Stmt_Tag {
-    NKI_Stmt_EXPR,
-    NKI_Stmt_ASSERT,
-    NKI_Stmt_RET,
-    NKI_Stmt_ASSIGN,
-    NKI_Stmt_IFSTM,
-    NKI_Stmt_FORLOOP,
-    NKI_Stmt_BREAKLOOP,
-    NKI_Stmt_CONTINUELOOP
+    NKI_Stmt_expr,
+    NKI_Stmt_assert,
+    NKI_Stmt_ret,
+    NKI_Stmt_assign,
+    NKI_Stmt_ifStm,
+    NKI_Stmt_forLoop,
+    NKI_Stmt_breakLoop,
+    NKI_Stmt_continueLoop
   } tag;
   union {
     struct NKI_Stmt_expr {
@@ -238,7 +238,7 @@ static inline struct NKI_Expr *mkNKI_Expr_value(struct NKI_Value *value,
   struct NKI_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = NKI_Expr_VALUE;
+  res->expr->tag = NKI_Expr_value;
   res->expr->value.value = value;
   return res;
 }
@@ -248,7 +248,7 @@ static inline struct NKI_Expr *mkNKI_Expr_var(const char *name,
   struct NKI_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = NKI_Expr_VAR;
+  res->expr->tag = NKI_Expr_var;
   res->expr->var.name = name;
   return res;
 }
@@ -259,7 +259,7 @@ static inline struct NKI_Expr *mkNKI_Expr_proj(struct NKI_Expr *expr,
   struct NKI_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = NKI_Expr_PROJ;
+  res->expr->tag = NKI_Expr_proj;
   res->expr->proj.expr = expr;
   res->expr->proj.name = name;
   return res;
@@ -270,7 +270,7 @@ static inline struct NKI_Expr *mkNKI_Expr_tuple(struct NKI_Expr_List *elements,
   struct NKI_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = NKI_Expr_TUPLE;
+  res->expr->tag = NKI_Expr_tuple;
   res->expr->tuple.elements = elements;
   return res;
 }
@@ -281,7 +281,7 @@ static inline struct NKI_Expr *mkNKI_Expr_access(struct NKI_Expr *expr,
   struct NKI_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = NKI_Expr_ACCESS;
+  res->expr->tag = NKI_Expr_access;
   res->expr->access.expr = expr;
   res->expr->access.indices = indices;
   return res;
@@ -294,7 +294,7 @@ static inline struct NKI_Expr *mkNKI_Expr_binOp(enum NKI_BinOp op,
   struct NKI_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = NKI_Expr_BINOP;
+  res->expr->tag = NKI_Expr_binOp;
   res->expr->binOp.op = op;
   res->expr->binOp.left = left;
   res->expr->binOp.right = right;
@@ -308,7 +308,7 @@ static inline struct NKI_Expr *mkNKI_Expr_ifExp(struct NKI_Expr *test,
   struct NKI_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = NKI_Expr_IFEXP;
+  res->expr->tag = NKI_Expr_ifExp;
   res->expr->ifExp.test = test;
   res->expr->ifExp.body = body;
   res->expr->ifExp.orelse = orelse;
@@ -321,7 +321,7 @@ mkNKI_Expr_call(struct NKI_Expr *f, struct NKI_Expr_List *args,
   struct NKI_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = NKI_Expr_CALL;
+  res->expr->tag = NKI_Expr_call;
   res->expr->call.f = f;
   res->expr->call.args = args;
   res->expr->call.keywords = keywords;
@@ -333,7 +333,7 @@ static inline struct NKI_Stmt *mkNKI_Stmt_expr(struct NKI_Expr *e,
   struct NKI_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = NKI_Stmt_EXPR;
+  res->stmt->tag = NKI_Stmt_expr;
   res->stmt->expr.e = e;
   return res;
 }
@@ -343,7 +343,7 @@ static inline struct NKI_Stmt *mkNKI_Stmt_assert(struct NKI_Expr *e,
   struct NKI_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = NKI_Stmt_ASSERT;
+  res->stmt->tag = NKI_Stmt_assert;
   res->stmt->assert.e = e;
   return res;
 }
@@ -353,7 +353,7 @@ static inline struct NKI_Stmt *mkNKI_Stmt_ret(struct NKI_Expr *e,
   struct NKI_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = NKI_Stmt_RET;
+  res->stmt->tag = NKI_Stmt_ret;
   res->stmt->ret.e = e;
   return res;
 }
@@ -365,7 +365,7 @@ static inline struct NKI_Stmt *mkNKI_Stmt_assign(struct NKI_Expr *x,
   struct NKI_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = NKI_Stmt_ASSIGN;
+  res->stmt->tag = NKI_Stmt_assign;
   res->stmt->assign.x = x;
   res->stmt->assign.ty = ty;
   res->stmt->assign.e = e;
@@ -379,7 +379,7 @@ static inline struct NKI_Stmt *mkNKI_Stmt_ifStm(struct NKI_Expr *e,
   struct NKI_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = NKI_Stmt_IFSTM;
+  res->stmt->tag = NKI_Stmt_ifStm;
   res->stmt->ifStm.e = e;
   res->stmt->ifStm.thn = thn;
   res->stmt->ifStm.els = els;
@@ -393,7 +393,7 @@ static inline struct NKI_Stmt *mkNKI_Stmt_forLoop(struct NKI_Expr *x,
   struct NKI_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = NKI_Stmt_FORLOOP;
+  res->stmt->tag = NKI_Stmt_forLoop;
   res->stmt->forLoop.x = x;
   res->stmt->forLoop.iter = iter;
   res->stmt->forLoop.body = body;
@@ -404,7 +404,7 @@ static inline struct NKI_Stmt *mkNKI_Stmt_breakLoop(struct region *region) {
   struct NKI_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = NKI_Stmt_BREAKLOOP;
+  res->stmt->tag = NKI_Stmt_breakLoop;
   return res;
 }
 
@@ -412,6 +412,6 @@ static inline struct NKI_Stmt *mkNKI_Stmt_continueLoop(struct region *region) {
   struct NKI_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = NKI_Stmt_CONTINUELOOP;
+  res->stmt->tag = NKI_Stmt_continueLoop;
   return res;
 }

--- a/interop/nkic/ast_python_core.h
+++ b/interop/nkic/ast_python_core.h
@@ -14,12 +14,12 @@ struct Python_Pos {
 
 struct Python_Const {
   enum Python_Const_Tag {
-    Python_Const_NONE,
-    Python_Const_BOOL,
-    Python_Const_INT,
-    Python_Const_FLOAT,
-    Python_Const_STRING,
-    Python_Const_ELLIPSIS
+    Python_Const_none,
+    Python_Const_bool,
+    Python_Const_int,
+    Python_Const_float,
+    Python_Const_string,
+    Python_Const_ellipsis
   } tag;
   union {
     struct Python_Const_bool {
@@ -37,62 +37,62 @@ struct Python_Const {
   };
 };
 
-enum Python_Ctx { Python_Ctx_Load, Python_Ctx_Store, Python_Ctx_Del };
+enum Python_Ctx { Python_Ctx_load, Python_Ctx_store, Python_Ctx_del };
 
-enum Python_BoolOp { Python_BoolOp_Land, Python_BoolOp_Lor };
+enum Python_BoolOp { Python_BoolOp_land, Python_BoolOp_lor };
 
 enum Python_CmpOp {
-  Python_CmpOp_Eq,
-  Python_CmpOp_Ne,
-  Python_CmpOp_Lt,
-  Python_CmpOp_Le,
-  Python_CmpOp_Gt,
-  Python_CmpOp_Ge,
-  Python_CmpOp_Is,
-  Python_CmpOp_IsNot,
-  Python_CmpOp_IsIn,
-  Python_CmpOp_NotIn
+  Python_CmpOp_eq,
+  Python_CmpOp_ne,
+  Python_CmpOp_lt,
+  Python_CmpOp_le,
+  Python_CmpOp_gt,
+  Python_CmpOp_ge,
+  Python_CmpOp_is,
+  Python_CmpOp_isNot,
+  Python_CmpOp_isIn,
+  Python_CmpOp_notIn
 };
 
 enum Python_UnaryOp {
-  Python_UnaryOp_Invert,
-  Python_UnaryOp_Not,
-  Python_UnaryOp_Uadd,
-  Python_UnaryOp_Usub
+  Python_UnaryOp_invert,
+  Python_UnaryOp_not,
+  Python_UnaryOp_uadd,
+  Python_UnaryOp_usub
 };
 
 enum Python_BinOp {
-  Python_BinOp_Add,
-  Python_BinOp_Sub,
-  Python_BinOp_Mul,
-  Python_BinOp_Matmul,
-  Python_BinOp_Div,
-  Python_BinOp_Mod,
-  Python_BinOp_Pow,
-  Python_BinOp_Lshift,
-  Python_BinOp_Rshift,
-  Python_BinOp_Or,
-  Python_BinOp_Xor,
-  Python_BinOp_And,
-  Python_BinOp_Floor
+  Python_BinOp_add,
+  Python_BinOp_sub,
+  Python_BinOp_mul,
+  Python_BinOp_matmul,
+  Python_BinOp_div,
+  Python_BinOp_mod,
+  Python_BinOp_pow,
+  Python_BinOp_lshift,
+  Python_BinOp_rshift,
+  Python_BinOp_or,
+  Python_BinOp_xor,
+  Python_BinOp_and,
+  Python_BinOp_floor
 };
 
 struct Python_Expr_ {
   enum Python_Expr_Tag {
-    Python_Expr_CONST,
-    Python_Expr_TENSOR,
-    Python_Expr_NAME,
-    Python_Expr_ATTR,
-    Python_Expr_TUPLE,
-    Python_Expr_LIST,
-    Python_Expr_SUBSCRIPT,
-    Python_Expr_SLICE,
-    Python_Expr_BOOLOP,
-    Python_Expr_BINOP,
-    Python_Expr_UNARYOP,
-    Python_Expr_COMPARE,
-    Python_Expr_IFEXP,
-    Python_Expr_CALL
+    Python_Expr_const,
+    Python_Expr_tensor,
+    Python_Expr_name,
+    Python_Expr_attr,
+    Python_Expr_tuple,
+    Python_Expr_list,
+    Python_Expr_subscript,
+    Python_Expr_slice,
+    Python_Expr_boolOp,
+    Python_Expr_binOp,
+    Python_Expr_unaryOp,
+    Python_Expr_compare,
+    Python_Expr_ifExp,
+    Python_Expr_call
   } tag;
   union {
     struct Python_Expr_const {
@@ -173,17 +173,17 @@ struct Python_Keyword {
 
 struct Python_Stmt_ {
   enum Python_Stmt_Tag {
-    Python_Stmt_PASS,
-    Python_Stmt_EXPR,
-    Python_Stmt_ASSERT,
-    Python_Stmt_RET,
-    Python_Stmt_ASSIGN,
-    Python_Stmt_AUGASSIGN,
-    Python_Stmt_ANNASSIGN,
-    Python_Stmt_IFSTM,
-    Python_Stmt_FORLOOP,
-    Python_Stmt_BREAKLOOP,
-    Python_Stmt_CONTINUELOOP
+    Python_Stmt_pass,
+    Python_Stmt_expr,
+    Python_Stmt_assert,
+    Python_Stmt_ret,
+    Python_Stmt_assign,
+    Python_Stmt_augAssign,
+    Python_Stmt_annAssign,
+    Python_Stmt_ifStm,
+    Python_Stmt_forLoop,
+    Python_Stmt_breakLoop,
+    Python_Stmt_continueLoop
   } tag;
   union {
     struct Python_Stmt_expr {
@@ -290,7 +290,7 @@ mkPython_Expr_const(struct Python_Const *value, struct region *region) {
   struct Python_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = Python_Expr_CONST;
+  res->expr->tag = Python_Expr_const;
   res->expr->c.value = value;
   return res;
 }
@@ -301,7 +301,7 @@ mkPython_Expr_tensor(struct Python_Expr_List *shape, const char *dtype,
   struct Python_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = Python_Expr_TENSOR;
+  res->expr->tag = Python_Expr_tensor;
   res->expr->tensor.shape = shape;
   res->expr->tensor.dtype = dtype;
   return res;
@@ -312,7 +312,7 @@ mkPython_Expr_name(const char *id, enum Python_Ctx ctx, struct region *region) {
   struct Python_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = Python_Expr_NAME;
+  res->expr->tag = Python_Expr_name;
   res->expr->name.id = id;
   res->expr->name.ctx = ctx;
   return res;
@@ -325,7 +325,7 @@ static inline struct Python_Expr *mkPython_Expr_attr(struct Python_Expr *value,
   struct Python_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = Python_Expr_ATTR;
+  res->expr->tag = Python_Expr_attr;
   res->expr->attr.value = value;
   res->expr->attr.id = id;
   res->expr->attr.ctx = ctx;
@@ -338,7 +338,7 @@ mkPython_Expr_tuple(struct Python_Expr_List *xs, enum Python_Ctx ctx,
   struct Python_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = Python_Expr_TUPLE;
+  res->expr->tag = Python_Expr_tuple;
   res->expr->tuple.xs = xs;
   res->expr->tuple.ctx = ctx;
   return res;
@@ -350,7 +350,7 @@ mkPython_Expr_list(struct Python_Expr_List *xs, enum Python_Ctx ctx,
   struct Python_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = Python_Expr_LIST;
+  res->expr->tag = Python_Expr_list;
   res->expr->list.xs = xs;
   res->expr->list.ctx = ctx;
   return res;
@@ -362,7 +362,7 @@ mkPython_Expr_subscript(struct Python_Expr *tensor, struct Python_Expr *index,
   struct Python_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = Python_Expr_SUBSCRIPT;
+  res->expr->tag = Python_Expr_subscript;
   res->expr->subscript.tensor = tensor;
   res->expr->subscript.index = index;
   res->expr->subscript.ctx = ctx;
@@ -376,7 +376,7 @@ static inline struct Python_Expr *mkPython_Expr_slice(struct Python_Expr *l,
   struct Python_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = Python_Expr_SLICE;
+  res->expr->tag = Python_Expr_slice;
   res->expr->slice.l = l;
   res->expr->slice.u = u;
   res->expr->slice.step = step;
@@ -389,7 +389,7 @@ mkPython_Expr_boolOp(enum Python_BoolOp op, struct Python_Expr_List *values,
   struct Python_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = Python_Expr_BOOLOP;
+  res->expr->tag = Python_Expr_boolOp;
   res->expr->boolOp.op = op;
   res->expr->boolOp.values = values;
   return res;
@@ -402,7 +402,7 @@ static inline struct Python_Expr *mkPython_Expr_binOp(enum Python_BinOp op,
   struct Python_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = Python_Expr_BINOP;
+  res->expr->tag = Python_Expr_binOp;
   res->expr->binOp.op = op;
   res->expr->binOp.left = left;
   res->expr->binOp.right = right;
@@ -415,7 +415,7 @@ mkPython_Expr_unaryOp(enum Python_UnaryOp op, struct Python_Expr *operand,
   struct Python_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = Python_Expr_UNARYOP;
+  res->expr->tag = Python_Expr_unaryOp;
   res->expr->unaryOp.op = op;
   res->expr->unaryOp.operand = operand;
   return res;
@@ -428,7 +428,7 @@ mkPython_Expr_compare(struct Python_Expr *left, struct Python_CmpOp_List *ops,
   struct Python_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = Python_Expr_COMPARE;
+  res->expr->tag = Python_Expr_compare;
   res->expr->compare.left = left;
   res->expr->compare.ops = ops;
   res->expr->compare.comparators = comparators;
@@ -441,7 +441,7 @@ mkPython_Expr_ifExp(struct Python_Expr *test, struct Python_Expr *body,
   struct Python_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = Python_Expr_IFEXP;
+  res->expr->tag = Python_Expr_ifExp;
   res->expr->ifExp.test = test;
   res->expr->ifExp.body = body;
   res->expr->ifExp.orelse = orelse;
@@ -455,7 +455,7 @@ mkPython_Expr_call(struct Python_Expr *f, struct Python_Expr_List *args,
   struct Python_Expr *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->expr->tag = Python_Expr_CALL;
+  res->expr->tag = Python_Expr_call;
   res->expr->call.f = f;
   res->expr->call.args = args;
   res->expr->call.keywords = keywords;
@@ -466,7 +466,7 @@ static inline struct Python_Stmt *mkPython_Stmt_pass(struct region *region) {
   struct Python_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = Python_Stmt_PASS;
+  res->stmt->tag = Python_Stmt_pass;
   return res;
 }
 
@@ -475,7 +475,7 @@ static inline struct Python_Stmt *mkPython_Stmt_expr(struct Python_Expr *e,
   struct Python_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = Python_Stmt_EXPR;
+  res->stmt->tag = Python_Stmt_expr;
   res->stmt->expr.e = e;
   return res;
 }
@@ -485,7 +485,7 @@ static inline struct Python_Stmt *mkPython_Stmt_assert(struct Python_Expr *e,
   struct Python_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = Python_Stmt_ASSERT;
+  res->stmt->tag = Python_Stmt_assert;
   res->stmt->assert.e = e;
   return res;
 }
@@ -495,7 +495,7 @@ static inline struct Python_Stmt *mkPython_Stmt_ret(struct Python_Expr *e,
   struct Python_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = Python_Stmt_RET;
+  res->stmt->tag = Python_Stmt_ret;
   res->stmt->ret.e = e;
   return res;
 }
@@ -506,7 +506,7 @@ mkPython_Stmt_assign(struct Python_Expr_List *xs, struct Python_Expr *e,
   struct Python_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = Python_Stmt_ASSIGN;
+  res->stmt->tag = Python_Stmt_assign;
   res->stmt->assign.xs = xs;
   res->stmt->assign.e = e;
   return res;
@@ -518,7 +518,7 @@ mkPython_Stmt_augAssign(struct Python_Expr *x, enum Python_BinOp op,
   struct Python_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = Python_Stmt_AUGASSIGN;
+  res->stmt->tag = Python_Stmt_augAssign;
   res->stmt->augAssign.x = x;
   res->stmt->augAssign.op = op;
   res->stmt->augAssign.e = e;
@@ -531,7 +531,7 @@ mkPython_Stmt_annAssign(struct Python_Expr *x, struct Python_Expr *annotation,
   struct Python_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = Python_Stmt_ANNASSIGN;
+  res->stmt->tag = Python_Stmt_annAssign;
   res->stmt->annAssign.x = x;
   res->stmt->annAssign.annotation = annotation;
   res->stmt->annAssign.value = value;
@@ -544,7 +544,7 @@ mkPython_Stmt_ifStm(struct Python_Expr *e, struct Python_Stmt_List *thn,
   struct Python_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = Python_Stmt_IFSTM;
+  res->stmt->tag = Python_Stmt_ifStm;
   res->stmt->ifStm.e = e;
   res->stmt->ifStm.thn = thn;
   res->stmt->ifStm.els = els;
@@ -558,7 +558,7 @@ mkPython_Stmt_forLoop(struct Python_Expr *x, struct Python_Expr *iter,
   struct Python_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = Python_Stmt_FORLOOP;
+  res->stmt->tag = Python_Stmt_forLoop;
   res->stmt->forLoop.x = x;
   res->stmt->forLoop.iter = iter;
   res->stmt->forLoop.body = body;
@@ -571,7 +571,7 @@ mkPython_Stmt_breakLoop(struct region *region) {
   struct Python_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = Python_Stmt_BREAKLOOP;
+  res->stmt->tag = Python_Stmt_breakLoop;
   return res;
 }
 
@@ -580,6 +580,6 @@ mkPython_Stmt_continueLoop(struct region *region) {
   struct Python_Stmt *res = region_alloc(region, sizeof(*res));
   if (!res)
     return NULL;
-  res->stmt->tag = Python_Stmt_CONTINUELOOP;
+  res->stmt->tag = Python_Stmt_continueLoop;
   return res;
 }

--- a/interop/nkic/gather.c
+++ b/interop/nkic/gather.c
@@ -214,7 +214,7 @@ static struct Python_Expr* const_expr(struct state *st, PyObject *obj) {
 
   e->expr->c.value = value(st, obj);
   if (e->expr->c.value) {
-    e->expr->tag = Python_Expr_CONST;
+    e->expr->tag = Python_Expr_const;
     return e;
   }
 
@@ -223,20 +223,20 @@ static struct Python_Expr* const_expr(struct state *st, PyObject *obj) {
 
   // Check for other types of supported global values
   if (PyTuple_Check(obj)) {
-    e->expr->tag = Python_Expr_TUPLE;
+    e->expr->tag = Python_Expr_tuple;
     e->expr->tuple.xs = const_exprs(st, obj);
-    e->expr->tuple.ctx = Python_Ctx_Load;
+    e->expr->tuple.ctx = Python_Ctx_load;
     return e;
   }
   else if (PyList_Check(obj)) {
-    e->expr->tag = Python_Expr_LIST;
+    e->expr->tag = Python_Expr_list;
     e->expr->list.xs = const_exprs(st, obj);
-    e->expr->list.ctx = Python_Ctx_Load;
+    e->expr->list.ctx = Python_Ctx_load;
     return e;
   }
   else if (PyModule_Check(obj)) {
     // TODO: can we just leave these undefined?
-    e->expr->tag = Python_Expr_CONST;
+    e->expr->tag = Python_Expr_const;
     e->expr->c.value = NULL;
     return e;
   }
@@ -354,7 +354,7 @@ static struct ref reference(struct state *st, struct Python_Expr *e) {
   if (!e) return ref;
 
   switch(e->expr->tag) {
-  case Python_Expr_NAME:
+  case Python_Expr_name:
     ref.name = (char*)e->expr->name.id;
     ref.obj = lookup(st, e->expr->name.id);
     if (!ref.obj) {
@@ -363,7 +363,7 @@ static struct ref reference(struct state *st, struct Python_Expr *e) {
     }
     break;
 
-  case Python_Expr_ATTR:
+  case Python_Expr_attr:
     ref = reference(st, e->expr->attr.value);
     if (!ref.obj) {
       ref.name = NULL;
@@ -408,14 +408,14 @@ static struct Python_Const* value(struct state *st, PyObject *obj) {
   struct Python_Const *c = region_alloc(st->region, sizeof(*c));
 
   if (Py_IsNone(obj)) {
-    c->tag = Python_Const_NONE;
+    c->tag = Python_Const_none;
   }
   else if (PyBool_Check(obj)) {
-    c->tag = Python_Const_BOOL;
+    c->tag = Python_Const_bool;
     c->b.value = Py_IsTrue(obj) != 0;
   }
   else if (PyLong_Check(obj)) {
-    c->tag = Python_Const_INT;
+    c->tag = Python_Const_int;
     int overflow = 0;
     long value = PyLong_AsLongAndOverflow(obj, &overflow);
     if (value == -1 && PyErr_Occurred()) {
@@ -432,7 +432,7 @@ static struct Python_Const* value(struct state *st, PyObject *obj) {
     c->i.value = (i32)value;
   }
   else if (PyFloat_Check(obj)) {
-    c->tag = Python_Const_FLOAT;
+    c->tag = Python_Const_float;
     double d = PyFloat_AsDouble(obj);
     if (PyErr_Occurred())
       return NULL;
@@ -440,13 +440,13 @@ static struct Python_Const* value(struct state *st, PyObject *obj) {
     c->f.value = (float)d;
   }
   else if (PyUnicode_Check(obj)) {
-    c->tag = Python_Const_STRING;
+    c->tag = Python_Const_string;
     c->s.value = py_strdup(st, obj);
     if (!c->s.value)
       return NULL;
   }
   else if (Py_IS_TYPE(obj, &PyEllipsis_Type)) {
-    c->tag = Python_Const_ELLIPSIS;
+    c->tag = Python_Const_ellipsis;
   }
   else {
     return NULL;
@@ -460,62 +460,62 @@ static struct Python_Const* value(struct state *st, PyObject *obj) {
 
 static enum Python_Ctx context(expr_context_ty ctx) {
   switch (ctx) {
-  case Load: return Python_Ctx_Load;
-  case Store: return Python_Ctx_Store;
-  case Del: return Python_Ctx_Del;
-  default: return Python_Ctx_Load;  // impossible (safe default)
+  case Load: return Python_Ctx_load;
+  case Store: return Python_Ctx_store;
+  case Del: return Python_Ctx_del;
+  default: return Python_Ctx_load;  // impossible (safe default)
   }
 }
 
 static enum Python_BoolOp boolop(boolop_ty op) {
   switch (op) {
-  case And: return Python_BoolOp_Land;
-  case Or: return Python_BoolOp_Lor;
+  case And: return Python_BoolOp_land;
+  case Or: return Python_BoolOp_lor;
   default: return (u32)-1; // impossible
   }
 }
 
 static enum Python_UnaryOp unaryop(unaryop_ty op) {
   switch (op) {
-  case Invert: return Python_UnaryOp_Invert;
-  case Not: return Python_UnaryOp_Not;
-  case UAdd: return Python_UnaryOp_Uadd;
-  case USub: return Python_UnaryOp_Usub;
+  case Invert: return Python_UnaryOp_invert;
+  case Not: return Python_UnaryOp_not;
+  case UAdd: return Python_UnaryOp_uadd;
+  case USub: return Python_UnaryOp_usub;
   default: return (u32)-1; // impossible
   }
 }
 
 static enum Python_BinOp binop(operator_ty op) {
   switch (op) {
-  case Add: return Python_BinOp_Add;
-  case Sub: return Python_BinOp_Sub;
-  case Mult: return Python_BinOp_Mul;
-  case MatMult: return Python_BinOp_Matmul;
-  case Div: return Python_BinOp_Div;
-  case Mod: return Python_BinOp_Mod;
-  case Pow: return Python_BinOp_Pow;
-  case LShift: return Python_BinOp_Lshift;
-  case RShift: return Python_BinOp_Rshift;
-  case BitOr: return Python_BinOp_Or;
-  case BitXor: return Python_BinOp_Xor;
-  case BitAnd: return Python_BinOp_And;
-  case FloorDiv: return Python_BinOp_Floor;
+  case Add: return Python_BinOp_add;
+  case Sub: return Python_BinOp_sub;
+  case Mult: return Python_BinOp_mul;
+  case MatMult: return Python_BinOp_matmul;
+  case Div: return Python_BinOp_div;
+  case Mod: return Python_BinOp_mod;
+  case Pow: return Python_BinOp_pow;
+  case LShift: return Python_BinOp_lshift;
+  case RShift: return Python_BinOp_rshift;
+  case BitOr: return Python_BinOp_or;
+  case BitXor: return Python_BinOp_xor;
+  case BitAnd: return Python_BinOp_and;
+  case FloorDiv: return Python_BinOp_floor;
   default: return (u32)-1;  // impossible
   }
 }
 
 static enum Python_CmpOp cmpop(cmpop_ty op) {
   switch (op) {
-  case Eq: return Python_CmpOp_Eq;
-  case NotEq: return Python_CmpOp_Ne;
-  case Lt: return Python_CmpOp_Lt;
-  case LtE: return Python_CmpOp_Le;
-  case Gt: return Python_CmpOp_Gt;
-  case GtE: return Python_CmpOp_Ge;
-  case Is: return Python_CmpOp_Is;
-  case IsNot: return Python_CmpOp_IsNot;
-  case In: return Python_CmpOp_IsIn;
-  case NotIn: return Python_CmpOp_NotIn;
+  case Eq: return Python_CmpOp_eq;
+  case NotEq: return Python_CmpOp_ne;
+  case Lt: return Python_CmpOp_lt;
+  case LtE: return Python_CmpOp_le;
+  case Gt: return Python_CmpOp_gt;
+  case GtE: return Python_CmpOp_ge;
+  case Is: return Python_CmpOp_is;
+  case IsNot: return Python_CmpOp_isNot;
+  case In: return Python_CmpOp_isIn;
+  case NotIn: return Python_CmpOp_notIn;
   default: return (u32)-1; // impossible
   }
 }
@@ -560,7 +560,7 @@ static struct Python_Expr* expr(struct state *st, struct _expr *python) {
 
   switch (python->kind) {
     case Constant_kind: {
-      e->tag = Python_Expr_CONST;
+      e->tag = Python_Expr_const;
       e->c.value = value(st, python->v.Constant.value);
       if (!e->c.value)
         res = NULL;
@@ -570,7 +570,7 @@ static struct Python_Expr* expr(struct state *st, struct _expr *python) {
     // We rely on the ctx value for a small optimization: we only need
     // to consider Loads
     case Name_kind: {
-      e->tag = Python_Expr_NAME;
+      e->tag = Python_Expr_name;
       e->name.id = py_strdup(st, python->v.Name.id);
       e->name.ctx = context(python->v.Name.ctx);
       if (!e->name.id) {
@@ -578,12 +578,12 @@ static struct Python_Expr* expr(struct state *st, struct _expr *python) {
         break;
       }
 
-      if (e->name.ctx == Python_Ctx_Load)
+      if (e->name.ctx == Python_Ctx_load)
         reference(st, res);
       break;
     }
     case Attribute_kind: {
-      e->tag = Python_Expr_ATTR;
+      e->tag = Python_Expr_attr;
       e->attr.value = expr(st, python->v.Attribute.value);
       e->attr.id = py_strdup(st, python->v.Attribute.attr);
       e->attr.ctx = context(python->v.Attribute.ctx);
@@ -592,14 +592,14 @@ static struct Python_Expr* expr(struct state *st, struct _expr *python) {
         break;
       }
 
-      if (e->attr.ctx == Python_Ctx_Load)
+      if (e->attr.ctx == Python_Ctx_load)
         reference(st, res);
       break;
     }
 
     // Sequences: Tuple and List
     case Tuple_kind: {
-      e->tag = Python_Expr_LIST;
+      e->tag = Python_Expr_tuple;
       e->tuple.xs = exprs(st, python->v.Tuple.elts);
       e->tuple.ctx = context(python->v.Tuple.ctx);
       if (!e->tuple.xs)
@@ -607,7 +607,7 @@ static struct Python_Expr* expr(struct state *st, struct _expr *python) {
       break;
     }
     case List_kind: {
-      e->tag = Python_Expr_LIST;
+      e->tag = Python_Expr_list;
       e->list.xs = exprs(st, python->v.List.elts);
       e->list.ctx = context(python->v.List.ctx);
       if (!e->list.xs)
@@ -617,7 +617,7 @@ static struct Python_Expr* expr(struct state *st, struct _expr *python) {
 
     // Index expressions
     case Subscript_kind: {
-      e->tag = Python_Expr_SUBSCRIPT;
+      e->tag = Python_Expr_subscript;
       e->subscript.tensor = expr(st, python->v.Subscript.value);
       e->subscript.index = expr(st, python->v.Subscript.slice);
       e->subscript.ctx = context(python->v.Subscript.ctx);
@@ -626,7 +626,7 @@ static struct Python_Expr* expr(struct state *st, struct _expr *python) {
       break;
     }
     case Slice_kind: {
-      e->tag = Python_Expr_SLICE;
+      e->tag = Python_Expr_slice;
       e->slice.l = expr(st, python->v.Slice.lower);
       e->slice.u = expr(st, python->v.Slice.upper);
       e->slice.step = expr(st, python->v.Slice.step);
@@ -637,7 +637,7 @@ static struct Python_Expr* expr(struct state *st, struct _expr *python) {
 
     // Operators
     case BoolOp_kind: {
-      e->tag = Python_Expr_BOOLOP;
+      e->tag = Python_Expr_boolOp;
       e->boolOp.op = boolop(python->v.BoolOp.op);
       e->boolOp.values = exprs(st, python->v.BoolOp.values);
       if (!e->boolOp.values)
@@ -645,7 +645,7 @@ static struct Python_Expr* expr(struct state *st, struct _expr *python) {
       break;
     }
     case BinOp_kind: {
-      e->tag = Python_Expr_BINOP;
+      e->tag = Python_Expr_binOp;
       e->binOp.op = binop(python->v.BinOp.op);
       e->binOp.left = expr(st, python->v.BinOp.left);
       e->binOp.right = expr(st, python->v.BinOp.right);
@@ -654,7 +654,7 @@ static struct Python_Expr* expr(struct state *st, struct _expr *python) {
       break;
     }
     case UnaryOp_kind: {
-      e->tag = Python_Expr_UNARYOP;
+      e->tag = Python_Expr_unaryOp;
       e->unaryOp.op = unaryop(python->v.UnaryOp.op);
       e->unaryOp.operand = expr(st, python->v.UnaryOp.operand);
       if (!e->unaryOp.operand)
@@ -662,7 +662,7 @@ static struct Python_Expr* expr(struct state *st, struct _expr *python) {
       break;
     }
     case Compare_kind: {
-      e->tag = Python_Expr_COMPARE;
+      e->tag = Python_Expr_compare;
       e->compare.left = expr(st, python->v.Compare.left);
       e->compare.ops = cmpops(st, python->v.Compare.ops);
       e->compare.comparators = exprs(st, python->v.Compare.comparators);
@@ -673,7 +673,7 @@ static struct Python_Expr* expr(struct state *st, struct _expr *python) {
 
     // Condition expression
     case IfExp_kind: {
-      e->tag = Python_Expr_IFEXP;
+      e->tag = Python_Expr_ifExp;
       e->ifExp.test = expr(st, python->v.IfExp.test);
       e->ifExp.body = expr(st, python->v.IfExp.body);
       e->ifExp.orelse = expr(st, python->v.IfExp.orelse);
@@ -684,7 +684,7 @@ static struct Python_Expr* expr(struct state *st, struct _expr *python) {
 
     // Function calls
     case Call_kind: {
-      e->tag = Python_Expr_CALL;
+      e->tag = Python_Expr_call;
       e->call.f = expr(st, python->v.Call.func);
       e->call.args = exprs(st, python->v.Call.args);
       e->call.keywords = keywords(st, python->v.Call.keywords);
@@ -845,12 +845,12 @@ static struct Python_Stmt* stmt(struct state *st, struct _stmt *python) {
 
   switch (python->kind) {
     case Pass_kind:
-      s->tag = Python_Stmt_PASS;
+      s->tag = Python_Stmt_pass;
       break;
 
     // Simple expressions
     case Expr_kind: {
-      s->tag = Python_Stmt_EXPR;
+      s->tag = Python_Stmt_expr;
       s->expr.e = expr(st, python->v.Return.value);
       if (!s->expr.e)
         res = NULL;
@@ -858,14 +858,14 @@ static struct Python_Stmt* stmt(struct state *st, struct _stmt *python) {
     }
     case Assert_kind: {
       // TODO capture message
-      s->tag = Python_Stmt_ASSERT;
+      s->tag = Python_Stmt_assert;
       s->assert.e = expr(st, python->v.Assert.test);
       if (!s->assert.e)
         res = NULL;
       break;
     }
     case Return_kind: {
-      s->tag = Python_Stmt_RET;
+      s->tag = Python_Stmt_ret;
       s->ret.e = expr(st, python->v.Return.value);
       if (!s->ret.e)
         res = NULL;
@@ -874,7 +874,7 @@ static struct Python_Stmt* stmt(struct state *st, struct _stmt *python) {
 
     // Assignments
     case Assign_kind: {
-      s->tag = Python_Stmt_ASSIGN;
+      s->tag = Python_Stmt_assign;
       s->assign.xs = exprs(st, python->v.Assign.targets);
       s->assign.e = expr(st, python->v.Assign.value);
       if (!s->assign.xs || !s->assign.e)
@@ -882,7 +882,7 @@ static struct Python_Stmt* stmt(struct state *st, struct _stmt *python) {
       break;
     }
     case AugAssign_kind: {
-      s->tag = Python_Stmt_AUGASSIGN;
+      s->tag = Python_Stmt_augAssign;
       s->augAssign.op = binop(python->v.AugAssign.op);
       s->augAssign.x = expr(st, python->v.AugAssign.target);
       s->augAssign.e = expr(st, python->v.AugAssign.value);
@@ -891,7 +891,7 @@ static struct Python_Stmt* stmt(struct state *st, struct _stmt *python) {
       break;
     }
     case AnnAssign_kind: {
-      s->tag = Python_Stmt_ANNASSIGN;
+      s->tag = Python_Stmt_annAssign;
       s->annAssign.x = expr(st, python->v.AnnAssign.target);
       s->annAssign.annotation = expr(st, python->v.AnnAssign.annotation);
       s->annAssign.value = expr(st, python->v.AnnAssign.value);
@@ -902,7 +902,7 @@ static struct Python_Stmt* stmt(struct state *st, struct _stmt *python) {
 
     // If statements
     case If_kind: {
-      s->tag = Python_Stmt_IFSTM;
+      s->tag = Python_Stmt_ifStm;
       s->ifStm.e = expr(st, python->v.If.test);
       if (s->ifStm.e) {
         // Note: we allow both to be empty
@@ -916,7 +916,7 @@ static struct Python_Stmt* stmt(struct state *st, struct _stmt *python) {
 
     // For loops
     case For_kind: {
-      s->tag = Python_Stmt_FORLOOP;
+      s->tag = Python_Stmt_forLoop;
       s->forLoop.x = expr(st, python->v.For.target);
       s->forLoop.iter = expr(st, python->v.For.iter);
       if (s->forLoop.x && s->forLoop.iter) {
@@ -929,11 +929,11 @@ static struct Python_Stmt* stmt(struct state *st, struct _stmt *python) {
       break;
     }
     case Break_kind: {
-      s->tag = Python_Stmt_BREAKLOOP;
+      s->tag = Python_Stmt_breakLoop;
       break;
     }
     case Continue_kind: {
-      s->tag = Python_Stmt_CONTINUELOOP;
+      s->tag = Python_Stmt_continueLoop;
       break;
     }
 


### PR DESCRIPTION
The change removes the modifications to names when generating C code. This change makes names easier to deal with in the code generators.