### PR TITLE
feat: implement specialize in C front-end

### DIFF
--- a/interop/nkic/frontend.h
+++ b/interop/nkic/frontend.h
@@ -46,6 +46,7 @@ void free_python_ast(struct _mod *m);
 
 // gather.c
 bool gather(struct kernel *k);
+bool specialize(struct kernel *k, PyObject *args, PyObject *kws);
 
 // simplify.c
 struct SimpResult {


### PR DESCRIPTION
Add an implementation of specialize in C version of the front-end. This patch also adds a new method to serialize the intermediate python core AST. This will be needed by the Lean code until we have a new parser.