### PR TITLE
chore: add standard derived instances to Python and NKI types

### DIFF
--- a/KLR/NKI/Basic.lean
+++ b/KLR/NKI/Basic.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul Govereau, Sean McLaughlin
 -/
 import KLR.Serde.Attr
+import KLR.Serde.Elab
+import KLR.Util
 
 /-!
 # Abstract syntax of NKI functions
@@ -14,12 +16,15 @@ syntax of NKI.
 -/
 
 namespace KLR.NKI
+open Lean (FromJson ToJson)
+open Serde (FromCBOR ToCBOR)
+open Util (FromSexp ToSexp)
 
 @[serde tag = 1]
 structure Pos where
   line : Nat
   column : Nat
-  deriving Repr
+  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 -- Note: the python int and float types are compatible with Lean's types
 -- The str type may require conversion (to UTF8).
@@ -32,7 +37,7 @@ inductive Value where
   | string (value : String)
   | ellipsis
   | tensor (shape : List Nat) (dtype : String)  -- TODO use Core Dtype
-  deriving Repr
+  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 @[serde tag = 3]
 inductive BinOp where
@@ -44,14 +49,14 @@ inductive BinOp where
   | add | sub | mul | div | mod | pow | floor
   -- bitwise
   | lshift | rshift | or | xor | and
-  deriving Repr
+  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 mutual
 @[serde tag = 4]
 structure Expr where
   expr : Expr'
   pos : Pos
-  deriving Repr
+  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 @[serde tag = 5]
 inductive Expr' where
@@ -63,19 +68,19 @@ inductive Expr' where
   | binOp (op : BinOp) (left right : Expr)
   | ifExp (test body orelse : Expr)
   | call (f: Expr) (args: List Expr) (keywords : List Keyword)
-  deriving Repr
+  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 @[serde tag = 6]
 inductive Index where
   | coord (i : Expr)
   | slice (l u step : Option Expr)
-  deriving Repr
+  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 @[serde tag = 7]
 structure Keyword where
   name : String
   expr : Expr
-  deriving Repr
+  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 end
 
 mutual
@@ -83,7 +88,7 @@ mutual
 structure Stmt where
   stmt : Stmt'
   pos : Pos
-  deriving Repr
+  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 @[serde tag = 9]
 inductive Stmt' where
@@ -95,14 +100,14 @@ inductive Stmt' where
   | forLoop (x : Expr) (iter: Expr) (body: List Stmt)
   | breakLoop
   | continueLoop
-  deriving Repr
+  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 end
 
 @[serde tag = 10]
 structure Param where
   name : String
   dflt : Option Expr
-  deriving Repr
+  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 @[serde tag = 11]
 structure Fun where
@@ -111,13 +116,13 @@ structure Fun where
   line : Nat
   body : List Stmt
   args : List Param
-  deriving Repr
+  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 @[serde tag = 12]
 structure Arg where
   name : String
   value : Expr
-  deriving Repr
+  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 @[serde tag = 13]
 structure Kernel where
@@ -125,4 +130,4 @@ structure Kernel where
   funs : List Fun
   args : List Arg
   globals : List Arg
-  deriving Repr
+  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp

--- a/KLR/Serde/Elab.lean
+++ b/KLR/Serde/Elab.lean
@@ -39,7 +39,9 @@ private def fnIdent (name : Name) (s : String) : Ident :=
 -- Generate a name suitable for an extern (C) symbol
 private def cIdent (name : Name) (s : String) : Ident :=
   let name := rmKLR name
-  let cname := (name.toString ++ "_" ++ s).replace "." "_"
+  let cname := name.toString ++ "_" ++ s
+  let cname := cname.replace "." "_"
+  let cname := cname.replace "'" "_"
   mkIdent cname.toName
 
 -- Make a list of parameter names, e.g.: x0, x1, ...

--- a/KLR/Util.lean
+++ b/KLR/Util.lean
@@ -8,6 +8,7 @@ import Util.Base64
 import Util.BitVec
 import Util.Common
 import Util.Enum
+import Util.Float
 import Util.FromBytes
 import Util.Gzip
 import Util.Hex

--- a/KLR/Util/Float.lean
+++ b/KLR/Util/Float.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+import Util.Common
+import Util.Plausible
+
+/-
+Utilities for the builtin Float types
+-/
+
+namespace KLR.Util
+
+/-
+A simple implementation of String -> Float
+
+Note: Could easily add support for e.g. 3e5 since ofScientific supports this.
+-/
+
+private def sign : List Char -> (Bool × List Char)
+  | '+' :: s => (true, s)
+  | '-' :: s => (false, s)
+  | s => (true, s)
+
+private def dot : List Char -> (Bool × List Char)
+  | '.' :: s => (true, s)
+  | s => (false, s)
+
+-- Note: String.toNat? would require we find the dot and split the string,
+-- so just do the whole thing here in one spot
+private def nat (acc : Nat) : List Char -> (Nat × List Char)
+  | [] => (acc, [])
+  | ch :: s => Id.run do
+      if ch < '0' || ch > '9' then
+        return (acc, ch :: s)
+      let n := ch.val - '0'.val
+      let acc := acc * 10 + n.toNat
+      nat acc s
+
+private def floatParts (cs : List Char) : (Bool × Nat × Nat) :=
+  let (sgn, cs) := sign cs
+  let (a, cs) := nat 0 cs
+  let (haveDot, cs) := dot cs
+  if haveDot then
+    let (b, cs') := nat 0 cs
+    let d := cs.length - cs'.length
+    let m := a * 10^d + b
+    (sgn, m, d)
+  else
+    (sgn, a, 0)
+
+def parseFloat (s : String) : Float :=
+  match s with
+  | "NaN" => 0.0 / 0.0
+  | "inf" => 1.0 / 0.0
+  | "-inf" => -1.0 / 0.0
+  | _ =>
+    let (sgn, m, d) := floatParts s.toList
+    let f := Float.ofScientific m true d
+    if sgn then f else -f
+
+private def roundTrip (f : Float) : Bool :=
+  let f' := parseFloat f.toString
+  if f.isNaN then f'.isNaN
+  else if f.isInf then f == f'
+  else (f - f').abs < 0.000001
+
+#guard roundTrip (0.0 / 0.0)
+#guard roundTrip (1.0 / 0.0)
+#guard roundTrip (-1.0 / 0.0)
+#guard roundTrip 0.0
+#guard roundTrip (-0.0)
+#guard roundTrip (-34.55)
+#guard roundTrip 3.1415926
+
+/--
+info: Unable to find a counter-example
+---
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+  example (f : Float) : roundTrip f := by plausible

--- a/KLR/Util/SexpTest.lean
+++ b/KLR/Util/SexpTest.lean
@@ -26,7 +26,20 @@ private def roundTrip [BEq a] [ToSexp a] [FromSexp a] (x : a) : Bool :=
   | .error _ => false
   | .ok z => x == z
 
+
 #guard roundTrip (HashMap.ofList [(1, 2), (3, 4)])
+
+#guard roundTrip true
+#guard roundTrip false
+
+#guard roundTrip 1.3
+#guard roundTrip (1.0 / 0.0)
+#guard roundTrip (-1.0 / 0.0)
+#guard toSexp (0.0 / 0.0) == atom "NaN"
+#guard
+  match @fromSexp? Float _ (atom "NaN") with
+  | .ok f => f.isNaN
+  | _ => false
 
 private structure Foo where
   x : Nat


### PR DESCRIPTION
Add automatically derived instances of BEq, Repr, and conversions to and from CBOR, Json and Sexp to the Python and NKI abstract syntax trees.