### PR TITLE
refactor: move position handling code to a common module

### DIFF
--- a/KLR/Compile.lean
+++ b/KLR/Compile.lean
@@ -1,0 +1,6 @@
+/-
+Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+import KLR.Compile.Pass

--- a/KLR/Compile/Pass.lean
+++ b/KLR/Compile/Pass.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau, Sean McLaughlin
+-/
+import KLR.Core.Basic
+import KLR.Util
+
+/-
+# Basic structure of a Compiler Pass
+-/
+
+namespace KLR.Compile.Pass
+export Core (Pos)
+
+/-
+# Assigning Source Locations to Errors and Warnings
+
+During a translation pass, errors and warnings are created using `throw` and
+`warn`. These functions create a "raw message" which only contains the text of
+the message. The `withPos p m` function is used to assign a source location,
+`p` any messages emitted by the monadic code, `m`. Upon return from `withPos`
+all messages are converted from raw messages to "located" messages which have a
+source location attached to them.
+
+Because the parser only deals with single functions, the source locations
+assigned by `withPos` are relative to the start of the function body (each
+function has a starting line of 1). The `withFile` function is used to assign a
+filename and absolute position within the file to each message. Upon return
+from `withFile` all messages are converted to "absolute" messages which have a
+filename and absolute position within the file attached to each message.
+
+A typical use looks like:
+
+```
+do
+  ...
+  withFile file line_offset do
+    ...
+    withPos pos1 do ...
+      ...
+      withPos pos2 do ...
+```
+
+The filename, line offset, and positions are found in the abstract syntax tree
+that is being processed. In the case of nested `withFile` or `withPos`, the
+inner-most call will assign the location information: these functions will
+ignore any messages that already have source locations attached.
+
+TODO: This monad is useful in lots of places, should live somewhere else.
+-/
+
+inductive PosError where
+  | raw (msg : String)
+  | located (pos : Pos) (msg : String)
+  | absolute (file : String) (pos : Pos) (msg : String)
+  deriving Inhabited, Repr
+
+namespace PosError
+
+def msg : PosError -> String
+  | .raw msg | .located _ msg | .absolute _ _ msg => msg
+
+def locate (pos : Pos) (pe : PosError) : PosError :=
+  match pe with
+  | .raw s => .located pos s
+  | .located ..
+  | .absolute .. => pe  -- do not change already located messages
+
+def addFile (file : String) (lineOffset : Nat) : PosError -> PosError
+  | .raw msg => .absolute file { line := lineOffset } msg
+  | .located pos msg => .absolute file { pos with line := pos.line + lineOffset } msg
+  | err => err  -- do not change already located message
+
+-- Note: This format should be understandable by upstream tools and callers
+instance : ToString PosError where
+  toString
+    | .raw m => m
+    | .located p m => s!"{p.line}:{p.column}:{m}"
+    | .absolute f p m => s!"{f}:{p.line}:{p.column}:{m}"
+
+end PosError
+
+structure PosState where
+  warnings : Array PosError := #[]  -- located warnings
+  newWarns : Array PosError := #[]  -- raw warnings
+
+namespace PosState
+
+/-
+When a new warning is emitted, it is initially unlocated and goes into the
+`newWarns` array to indicate that it needs to be located.
+-/
+def warn (msg : String) (ps : PosState) : PosState :=
+  { ps with
+    newWarns := ps.newWarns.push (.raw msg)
+  }
+
+/-
+When we `locate` a state, all new warnings are given the same position and
+moves to the `warnings` array of located warnings.
+-/
+def locate (pos : Pos) (ps : PosState) : PosState :=
+  { ps with
+    warnings := ps.warnings.append (ps.newWarns.map (.locate pos))
+    newWarns := #[]
+  }
+
+/-
+When we add a file name, we first locate any unlocated warnings, and then we
+add a filename to any warnings without one.
+The order of operations is: warn, locate, addFile.
+-/
+def addFile (file : String) (lineOffset : Nat) (ps : PosState) : PosState :=
+  { ps.locate { line := lineOffset, column := 0 } with
+    warnings := ps.warnings.map (.addFile file lineOffset)
+  }
+
+/-
+We should always have at least one `locate` or `addFile` at the outermost
+level, or we may lose warnings trapped in the `newWarn` array. The `finalize`
+function can be used to make sure all warnings are moved over.
+-/
+def finalize (file : String) (ps : PosState) : PosState :=
+  addFile file 0 ps
+
+end PosState
+
+abbrev PosM := EStateM PosError PosState
+
+namespace PosM
+
+instance : MonadExceptOf String PosM where
+  throw msg := throw (.raw msg)
+  tryCatch m f := tryCatch m (fun e => f e.msg)
+
+def withPos (pos : Pos) (m : PosM a) : PosM a :=
+  fun s => match m s with
+    | .ok x s => .ok x (s.locate pos)
+    | .error e s => .error (e.locate pos) (s.locate pos)
+
+def withFile (file : String) (lineOffset : Nat) (m : PosM a) : PosM a :=
+  fun s => match m s with
+    | .ok x s => .ok x (s.addFile file lineOffset)
+    | .error e s => .error (e.addFile file lineOffset) (s.addFile file lineOffset)
+
+end PosM
+
+-- Emit a warning / linter message
+def warn (msg : String) : PosM Unit :=
+  modify (PosState.warn msg)
+
+/-
+PosM will often be used within a monad transformer, so we provide "unlifted"
+versions of `withPos` and `withFile` for convenience. Note: The standard library
+provides MonadControl instances for the common monads and monad transformers.
+-/
+
+def withPos [Monad m] [MonadControlT PosM m]
+            (pos : Pos) (x : m a) : m a :=
+  control fun mapInBase => (PosM.withPos pos) (mapInBase x)
+
+def withFile [Monad m] [MonadControlT PosM m]
+             (file : String) (lineOffset : Nat) (x : m a) : m a :=
+  control fun mapInBase => (PosM.withFile file lineOffset) (mapInBase x)
+
+abbrev PassM st := StateT st PosM
+

--- a/KLR/Core/Basic.lean
+++ b/KLR/Core/Basic.lean
@@ -5,7 +5,10 @@ Authors: Paul Govereau, Sean McLaughlin
 -/
 import Init.Data.Int.Basic
 import KLR.Core.Operators
+import KLR.Serde.Attr
+import KLR.Serde.Elab
 import KLR.Util
+import Lean
 
 /-!
 # Abstract syntax of Core NKL language
@@ -14,6 +17,21 @@ This language is the result of "tracing", and is used as the
 portable format, a.k.a. Kernel Language Representation (KLR).
 -/
 namespace KLR.Core
+open Lean (FromJson ToJson)
+open Serde (FromCBOR ToCBOR)
+open Util (FromSexp ToSexp)
+
+/-
+A source position records the location of a statement in the original program.
+-/
+
+@[serde tag = 100]
+structure Pos where
+  line : Nat
+  column : Nat := 0
+  lineEnd : Option Nat := none
+  columnEnd : Option Nat := none
+  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 /-
 A tensor shape is a list of the sizes of each dimension of the tensor. By

--- a/KLR/NKI/Basic.lean
+++ b/KLR/NKI/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul Govereau, Sean McLaughlin
 -/
+import KLR.Core
 import KLR.Serde.Attr
 import KLR.Serde.Elab
 import KLR.Util
@@ -20,15 +21,11 @@ open Lean (FromJson ToJson)
 open Serde (FromCBOR ToCBOR)
 open Util (FromSexp ToSexp)
 
-@[serde tag = 1]
-structure Pos where
-  line : Nat
-  column : Nat
-  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
+export Core (Pos)
 
 -- Note: the python int and float types are compatible with Lean's types
 -- The str type may require conversion (to UTF8).
-@[serde tag = 2]
+@[serde tag = 1]
 inductive Value where
   | none
   | bool (value : Bool)
@@ -39,7 +36,7 @@ inductive Value where
   | tensor (shape : List Nat) (dtype : String)  -- TODO use Core Dtype
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
-@[serde tag = 3]
+@[serde tag = 2]
 inductive BinOp where
   -- logical
   | land | lor
@@ -52,13 +49,13 @@ inductive BinOp where
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 mutual
-@[serde tag = 4]
+@[serde tag = 3]
 structure Expr where
   expr : Expr'
   pos : Pos
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
-@[serde tag = 5]
+@[serde tag = 4]
 inductive Expr' where
   | value (value : Value)
   | var (name : String)
@@ -70,13 +67,13 @@ inductive Expr' where
   | call (f: Expr) (args: List Expr) (keywords : List Keyword)
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
-@[serde tag = 6]
+@[serde tag = 5]
 inductive Index where
   | coord (i : Expr)
   | slice (l u step : Option Expr)
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
-@[serde tag = 7]
+@[serde tag = 6]
 structure Keyword where
   name : String
   expr : Expr
@@ -84,13 +81,13 @@ structure Keyword where
 end
 
 mutual
-@[serde tag = 8]
+@[serde tag = 7]
 structure Stmt where
   stmt : Stmt'
   pos : Pos
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
-@[serde tag = 9]
+@[serde tag = 8]
 inductive Stmt' where
   | expr (e : Expr)
   | assert (e : Expr)
@@ -103,13 +100,13 @@ inductive Stmt' where
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 end
 
-@[serde tag = 10]
+@[serde tag = 9]
 structure Param where
   name : String
   dflt : Option Expr
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
-@[serde tag = 11]
+@[serde tag = 10]
 structure Fun where
   name : String
   file : String
@@ -118,13 +115,13 @@ structure Fun where
   args : List Param
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
-@[serde tag = 12]
+@[serde tag = 11]
 structure Arg where
   name : String
   value : Expr
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
-@[serde tag = 13]
+@[serde tag = 12]
 structure Kernel where
   entry : String
   funs : List Fun

--- a/KLR/NKI/Simplify.lean
+++ b/KLR/NKI/Simplify.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul Govereau, Sean McLaughlin
 -/
+import KLR.Compile.Pass
 import KLR.NKI.Basic
 import KLR.Python
 import KLR.Util
@@ -12,162 +13,9 @@ Simplification pass: convert from Python Core to NKI.
 -/
 
 namespace KLR.NKI
+open Compile.Pass
 
-/-
-# Assigning Source Locations to Errors and Warnings
-
-During a translation pass, errors and warnings are created using `throw` and
-`warn`. These functions create a "raw message" which only contains the text of
-the message. The `withPos p m` function is used to assign a source location,
-`p` any messages emitted by the monadic code, `m`. Upon return from `withPos`
-all messages are converted from raw messages to "located" messages which have a
-source location attached to them.
-
-Because the parser only deals with single functions, the source locations
-assigned by `withPos` are relative to the start of the function body (each
-function has a starting line of 1). The `withFile` function is used to assign a
-filename and absolute position within the file to each message. Upon return
-from `withFile` all messages are converted to "absolute" messages which have a
-filename and absolute position within the file attached to each message.
-
-A typical use looks like:
-
-```
-do
-  ...
-  withFile file line_offset do
-    ...
-    withPos pos1 do ...
-      ...
-      withPos pos2 do ...
-```
-
-The filename, line offset, and positions are found in the abstract syntax tree
-that is being processed. In the case of nested `withFile` or `withPos`, the
-inner-most call will assign the location information: these functions will
-ignore any messages that already have source locations attached.
-
-TODO: This monad is useful in lots of places, should live somewhere else.
--/
-
-inductive PosError where
-  | raw (msg : String)
-  | located (pos : Pos) (msg : String)
-  | absolute (file : String) (pos : Pos) (msg : String)
-  deriving Inhabited, Repr
-
-namespace PosError
-
-def msg : PosError -> String
-  | .raw msg | .located _ msg | .absolute _ _ msg => msg
-
-def locate (pos : Pos) (pe : PosError) : PosError :=
-  match pe with
-  | .raw s => .located pos s
-  | .located ..
-  | .absolute .. => pe  -- do not change already located messages
-
-def addFile (file : String) (lineOffset : Nat) : PosError -> PosError
-  | .raw msg => .absolute file { line := lineOffset, column := 0 } msg
-  | .located pos msg => .absolute file { pos with line := pos.line + lineOffset } msg
-  | err => err  -- do not change already located message
-
--- Note: This format should be understandable by upstream tools and callers
-instance : ToString PosError where
-  toString
-    | .raw m => m
-    | .located p m => s!"{p.line}:{p.column}:{m}"
-    | .absolute f p m => s!"{f}:{p.line}:{p.column}:{m}"
-
-end PosError
-
-structure PosState where
-  warnings : Array PosError := #[]  -- located warnings
-  newWarns : Array PosError := #[]  -- raw warnings
-
-namespace PosState
-
-/-
-When a new warning is emitted, it is initially unlocated and goes into the
-`newWarns` array to indicate that it needs to be located.
--/
-def warn (msg : String) (ps : PosState) : PosState :=
-  { ps with
-    newWarns := ps.newWarns.push (.raw msg)
-  }
-
-/-
-When we `locate` a state, all new warnings are given the same position and
-moves to the `warnings` array of located warnings.
--/
-def locate (pos : Pos) (ps : PosState) : PosState :=
-  { ps with
-    warnings := ps.warnings.append (ps.newWarns.map (.locate pos))
-    newWarns := #[]
-  }
-
-/-
-When we add a file name, we first locate any unlocated warnings, and then we
-add a filename to any warnings without one.
-The order of operations is: warn, locate, addFile.
--/
-def addFile (file : String) (lineOffset : Nat) (ps : PosState) : PosState :=
-  { ps.locate { line := lineOffset, column := 0 } with
-    warnings := ps.warnings.map (.addFile file lineOffset)
-  }
-
-/-
-We should always have at least one `locate` or `addFile` at the outermost
-level, or we may lose warnings trapped in the `newWarn` array. The `finalize`
-function can be used to make sure all warnings are moved over.
--/
-def finalize (file : String) (ps : PosState) : PosState :=
-  addFile file 0 ps
-
-end PosState
-
-abbrev PosM := EStateM PosError PosState
-
-namespace PosM
-
-instance : MonadExceptOf String PosM where
-  throw msg := throw (.raw msg)
-  tryCatch m f := tryCatch m (fun e => f e.msg)
-
-def withPos (pos : Pos) (m : PosM a) : PosM a :=
-  fun s => match m s with
-    | .ok x s => .ok x (s.locate pos)
-    | .error e s => .error (e.locate pos) (s.locate pos)
-
-def withFile (file : String) (lineOffset : Nat) (m : PosM a) : PosM a :=
-  fun s => match m s with
-    | .ok x s => .ok x (s.addFile file lineOffset)
-    | .error e s => .error (e.addFile file lineOffset) (s.addFile file lineOffset)
-
-end PosM
-
--- Emit a warning / linter message
-def warn (msg : String) : PosM Unit :=
-  modify (PosState.warn msg)
-
-/-
-PosM will often be used within a monad transformer, so we provide "unlifted"
-versions of `withPos` and `withFile` for convenience. Note: The standard library
-provides MonadControl instances for the common monads and monad transformers.
--/
-
-def withPos [Monad m] [MonadControlT PosM m]
-            (pos : Pos) (x : m a) : m a :=
-  control fun mapInBase => (PosM.withPos pos) (mapInBase x)
-
-def withFile [Monad m] [MonadControlT PosM m]
-             (file : String) (lineOffset : Nat) (x : m a) : m a :=
-  control fun mapInBase => (PosM.withFile file lineOffset) (mapInBase x)
-
-/-
-# Simplification
--/
-
+-- No extra state needed: use PosM instead of PassM
 abbrev Simplify := PosM
 
 /-
@@ -176,9 +24,6 @@ abbrev Simplify := PosM
 Note: Tensor values are handled as part of the expressions.
 We can change this: it is controlled by gather.
 -/
-
-private def pos (p : Python.Pos) : Pos :=
-  { line := p.lineno, column := p.col_offset }
 
 private def value : Python.Const -> Value
   | .none => .none
@@ -253,7 +98,7 @@ private def nat : Python.Expr' -> Simplify Nat
 
 private def shape : List Python.Expr -> Simplify (List Nat)
   | [] => return []
-  | ⟨ e, p ⟩ :: xs => return (<- withPos (pos p) (nat e)) :: (<- shape xs)
+  | ⟨ e, p ⟩ :: xs => return (<- withPos p (nat e)) :: (<- shape xs)
 
 /-
 # Expression simplification
@@ -267,7 +112,7 @@ is short.
 -/
 mutual
 private def expr (e : Python.Expr) : Simplify Expr := do
-  let pos := pos e.pos
+  let pos := e.pos
   let e' <- withPos pos (expr' e.expr)
   return ⟨ e', pos ⟩
   termination_by sizeOf e
@@ -308,7 +153,7 @@ private def expr' (e' : Python.Expr') : Simplify Expr' :=
 
 private def indexes (e : Python.Expr) : Simplify (List Index) := do
   match e with
-  | ⟨ e', p ⟩ => withPos (pos p) do
+  | ⟨ e', p ⟩ => withPos p do
     match e' with
     | .slice l u step => do
       let l <- l.attach.mapM fun ⟨ e, _ ⟩ => expr e
@@ -316,13 +161,13 @@ private def indexes (e : Python.Expr) : Simplify (List Index) := do
       let step <- step.attach.mapM fun ⟨ e, _ ⟩ => expr e
       return [.slice l u step]
     | .tuple l _ | .list l _ => return (<- exprs l).map .coord
-    | e' => return [.coord ⟨ <- expr' e', pos p⟩]
+    | e' => return [.coord ⟨ <- expr' e', p⟩]
   termination_by sizeOf e
 
 private def keywords (ks : List Python.Keyword) : Simplify (List Keyword) := do
   match ks with
   | [] => return []
-  | ⟨ n, e, p ⟩ :: ks => withPos (pos p) do return ⟨ n, <- expr e ⟩ :: (<- keywords ks)
+  | ⟨ n, e, p ⟩ :: ks => withPos p do return ⟨ n, <- expr e ⟩ :: (<- keywords ks)
   termination_by sizeOf ks
 end
 
@@ -350,7 +195,7 @@ def assign (xs : List Expr) (e : Expr) : Simplify (List Stmt') := do
 
 mutual
 private def stmt (s : Python.Stmt) : Simplify (List Stmt) := do
-  let p := pos (s.pos)
+  let p := s.pos
   let l <- withPos p (stmt' s.stmt)
   return l.map fun s => ⟨ s, p ⟩
   termination_by sizeOf s

--- a/KLR/Trace/Tensor.lean
+++ b/KLR/Trace/Tensor.lean
@@ -38,7 +38,7 @@ def declare (name : String)
             (dtype : Dtype) (shape : Shape) (memory : Memory)
             : Trace TensorName := do
   let pos := (<- get).pos
-  let tname := s!"{name}.{pos.lineno}.{pos.col_offset}"
+  let tname := s!"{name}.{pos.line}.{pos.column}"
   TensorName.make tname dtype shape $ some {
     memory := memory
     size   := Address.defaultSize shape dtype

--- a/KLR/Trace/Types.lean
+++ b/KLR/Trace/Types.lean
@@ -174,7 +174,7 @@ abbrev Env := Lean.RBMap Name Term compare
 
 structure State where
   fvn : Nat := 0
-  pos : Pos := { }
+  pos : Pos := { line := 0 }
   globals : Env := ∅
   locals : Env := ∅
   body : Array Stmt := #[]
@@ -195,7 +195,7 @@ inductive TraceErr where
   | formatted : String -> TraceErr
 
 instance : Inhabited TraceErr where
-  default := .located {} ""
+  default := .located { line := 0 } ""
 
 abbrev Trace := EStateM TraceErr State
 
@@ -224,7 +224,7 @@ errors.
 -/
 def withSrc (line : Nat) (source : String) (m : Trace a) : Trace a := fun s =>
   let p' := s.pos
-  match m { s with pos := {} } with
+  match m { s with pos := { line := 0 } } with
   | .ok x s => .ok x { s with pos := p' }
   | .error (.located p e) s =>
     .error (.formatted $ Python.Parsing.genError line source e p)
@@ -294,7 +294,7 @@ where
   addWarnings s str := if showWarnings then addWarn s str else str
   addWarn s str := s.warnings.foldl warnStr str
   warnStr str pw :=
-    if pw.fst == {} then
+    if pw.fst == { line := 0 } then
       s!"warning: {pw.snd}\n{str}"
     else
-      s!"warning:{pw.fst.lineno}: {pw.snd}\n{str}"
+      s!"warning:{pw.fst.line}: {pw.snd}\n{str}"

--- a/docs/disk_format.md
+++ b/docs/disk_format.md
@@ -1,0 +1,16 @@
+# KLR On-Disk Format
+
+KLR uses [CBOR](https://cbor.io) as its on-disk format.
+
+The exact details are stull in flux.
+
+## Assignment of tags
+
+| Lean Type | Type Tag |
+|-|-|
+| Internal ASTs | 1 - 99 |
+| Core.* | 100 - 149 |
+| Core.Operators.* | 150 - 234 |
+| KLRMetaData | 235 (0xeb) |
+| Contents | 236 (0xec) |
+| Option | 255 (0xff) |


### PR DESCRIPTION
This patch moves some code form the NKI Simplify pass into a common module. In addition, the ASTs are modified to use a common source position structure, instead of each one having its own version. I also added some notes on the CBOR tag conventions I have been following (subject to change).