### PR TITLE
Upload sdist to PyPI, and tweaks to support Brazil's Python3PBuildTool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,12 +84,24 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 99.0
           CIBW_BUILD_VERBOSITY: 1
         run: |
-          pip install cibuildwheel
+          pip install cibuildwheel build
           bin/make-wheel
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./.wheel/wheelhouse/*.whl
+
+      # Only upload sdist from an x64 linux machine.
+      # In a normal python package the sdist would be identical regardless of which
+      # platform/arch generated it. But we want to include klr.bin, which is
+      # platform specific and currently built outside the normal python tool ecosystem.
+      # So let's include the one platform-arch that's most useful to us right now.
+      - name: Upload sdist (Ubuntu x64 only)
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./.wheel/wheelhouse/*.tar.gz
 
   # Mostly followed guides here:
   # - https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,7 @@ __pycache__/
 *.so
 *.dSYM
 .vscode/
-/.wheel/
+*.egg-info/
+build/
+dist/
+klr.bin

--- a/bin/make-wheel
+++ b/bin/make-wheel
@@ -11,7 +11,6 @@ lake build
 
 # Get Python packages
 cp -R $PYTHON_DIR/* $WHEEL_DIR
-cp $ROOT/LICENSE $WHEEL_DIR
 
 # Get klr binary
 cp $ROOT/.lake/build/bin/klr $WHEEL_DIR/klr/klr.bin
@@ -19,13 +18,16 @@ cp $ROOT/.lake/build/bin/klr $WHEEL_DIR/klr/klr.bin
 cd $WHEEL_DIR
 
 if [ -z "${GITHUB_RUN_ID+x}" ]; then
-  echo "Building wheel locally"
+  echo "Building wheel and sdist locally"
   python -m build
 else
+  echo "Building sdist"
+  python -m build --sdist --outdir ./wheelhouse
+
   # https://github.com/pypa/cibuildwheel
   # NB: I could never get this to run on my mac locally. I got it to
   # work on linux with no trouble.
-  echo "Building wheel via GitHub Actions"
+  echo "Building wheels via GitHub Actions"
   python -m cibuildwheel --output-dir ./wheelhouse
 fi
 

--- a/interop/LICENSE
+++ b/interop/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/interop/pyproject.toml
+++ b/interop/pyproject.toml
@@ -1,7 +1,6 @@
 # NB: All this setuptools stuff took about 1000 hours to figure out so never delete this.
 [build-system]
-#requires = ["setuptools>=61.0"]
-requires = ["setuptools"]
+requires = ["setuptools==68.0.0"] # version used by Brazil's Python3PBuildTool as of 2025.07.02
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -13,7 +12,7 @@ authors = [
 ]
 description = "Intermediate langauge for tensor compilers"
 readme = "README.md"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 keywords = ["trainium", "tpu", "pallas", "triton", "gpu"]
 
 # Note, dependencies here are "abstract" while the same
@@ -42,26 +41,6 @@ packages = ["klr"]
 [project.scripts]
 klr = "klr._cli:run_klr"
 klr-gather = "klr._cli:gather"
-
-# Note, because we are building an extension module, we will get arch specific wheels.
-# This is important because we are putting an arch-specific binary into the wheel
-# as an "extra" file.
-[[tool.setuptools.ext-modules]]
-name = "klr.frontend"
-sources = [
-    "klr/cbor.c"
-  , "klr/frontend.c"
-  , "klr/gather.c"
-  , "klr/peg_parser.c"
-  , "klr/region.c"
-  , "klr/serde.c"
-  , "klr/serde_common.c"
-  , "klr/serde_file.c"
-  , "klr/serde_nki.c"
-  , "klr/serde_python_core.c"
-  , "klr/simplify.c"
-  , "klr/topy_nki.c"
-  ]
 
 [tool.cibuildwheel]
 # Skip unsupported python versions as well as 32-bit platforms, which are not supported anymore.

--- a/interop/setup.py
+++ b/interop/setup.py
@@ -1,0 +1,40 @@
+from setuptools import Extension, setup
+import os
+import sys
+
+# MACOSX_DEPLOYMENT_TARGET tells compiler the oldest macOS version to support.
+# It also determines the "macosx_13_0" part of the wheel name,
+# and pip won't install that wheel on macOS older than that.
+# If we don't set MACOSX_DEPLOYMENT_TARGET explicitly, setuptools will set
+# it to whatever your python installation was built with,
+# and if you used the python.org installer it's something ancient like 10.9,
+# which causes compiler warnings about modern-ish things like aligned_alloc().
+if sys.platform == 'darwin' and not os.getenv('MACOSX_DEPLOYMENT_TARGET'):
+  os.environ['MACOSX_DEPLOYMENT_TARGET'] = '13.0'
+
+# Note, because we are building an extension module, we will get arch specific wheels.
+# This is important because we are putting an arch-specific binary into the wheel
+# as an "extra" file.
+#
+# TODO: move this to pyproject.toml once Brazil supports newer versions of setuptools
+setup(
+  ext_modules=[
+    Extension(
+      name="klr.frontend",
+      sources=[
+        "klr/cbor.c",
+        "klr/frontend.c",
+        "klr/gather.c",
+        "klr/peg_parser.c",
+        "klr/region.c",
+        "klr/serde.c",
+        "klr/serde_common.c",
+        "klr/serde_file.c",
+        "klr/serde_nki.c",
+        "klr/serde_python_core.c",
+        "klr/simplify.c",
+        "klr/topy_nki.c",
+      ],
+    ),
+  ],
+)


### PR DESCRIPTION
Brazil's Python3PBuildTool requires an [sdist](https://docs.python.org/3.10/distutils/sourcedist.html) of the python project, and it's currently using older version of setuptools (68.0.0).

Tweaks:
- Copy LICENSE file into python project dir (because it's simpler than relying on a custom script to inject it as the wheels are being built)
- Some tweaks to `pyproject.toml` to work with older setuptools:
    - require exact setuptools version used in Brazil, so we catch incompatibilities sooner
    - tweak how `license` was defined
    - had to move `tool.setuptools.ext-modules` definitions to `setup.py`
    
Also, fixed our publishing steps to also upload a source distribution (aka "sdist", aka `*.tar.gz` file) to PyPI, in addition to the `*.whl` files. The sdist comes from the `CI / build (ubuntu-latest)` run. I did that so the `klr.bin` included with the sdist would be one that works on x86_64 Linux (I've tried running it on Amazon Linux 2 and it seemed to work).