### PR TITLE
Remove __STDC_VERSION__ check, to support GCC 7.3

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -56,7 +56,7 @@ To demonstrate the Python API, we will use a simple function that adds two
 numbers. To follow along, copy the code below into a new file called `test.py`.
 
 ```python
-def kernel(a, b):
+def kernel_function(a, b):
   return a + b
 ```
 
@@ -68,10 +68,10 @@ two steps using the KLR API by adding the following to our `test.py` file.
 
 ```python
 if __name__ == "__main__":
-  import klr.frontend as fs
+  import klr.frontend as fe
 
-  # Create KLR kernel object for "kernel" function
-  kernel = fe.Kernel(kernel)
+  # Create KLR kernel object for kernel function
+  kernel = fe.Kernel(kernel_function)
 
   # Specialize to specific arguments
   kernel.specialize(1, 2)

--- a/interop/klr/stdc.h
+++ b/interop/klr/stdc.h
@@ -8,10 +8,6 @@ Authors: Paul Govereau, Sean McLaughlin
 // A simple header file to check the C version and bring C standard
 // definitions into scope.
 
-#if __STDC__ != 1 || __STDC_VERSION__ < 201710L
-#error Compiler does not support C17
-#endif
-
 #if defined(__STDC_NO_ATOMICS__)
 #error Compiler does not support atomic types
 #endif


### PR DESCRIPTION
GCC 7.3 is the default compiler on Amazon Linux 2 Cloud Desktops. It failed due to the `__STDC_VERSION__ < 201710L` check. If I remove the check, everything still works so I guess it has the features we need. And if it didn't have a function, the compiler would fail when it saw that function, so omitting the check seems fine for now.

Also fix a typo, and variable shadowing, in getting_started.md