### PR TITLE
chore: Have FromSexp throw on unknown fields

### DIFF
--- a/KLR/Util.lean
+++ b/KLR/Util.lean
@@ -15,6 +15,7 @@ import Util.Hex
 import Util.Json
 import Util.ListJson
 import Util.MD5
+import Util.Meta
 import Util.NumBytes
 import Util.NumBytesTest
 import Util.Padding

--- a/KLR/Util/Meta.lean
+++ b/KLR/Util/Meta.lean
@@ -1,0 +1,29 @@
+import Lean.Elab
+import Util.Common
+
+open KLR(Err)
+open Lean(MonadError Name Syntax Term)
+open Lean.Elab.Term(TermElabM elabBinders elabTerm)
+
+/-
+This namespace is intended to be a library of utilities for
+metaprogramming in KLR. The functions we've been using are spread
+over many files and namespaces, and are hard to remember. Let's use
+this to organize as many of our standard patterns as possible. Some
+of them, like stringToStrLit are just abbreviations for other library
+functions. Even so, I still think there's value to having them in one spot.
+-/
+namespace KLR.Util.Meta
+
+def stringToStrLit (s : String) : Term := Syntax.mkStrLit s
+
+def nameToIdent (n : Name) : Term := Lean.mkIdent n
+
+def nameToString [Monad m] [MonadError m] (n : Name) : m String := do
+  let .str _ s := n | throwError "Not a string name"
+  return s
+
+def nameToStrLit [Monad m] [MonadError m] (n : Name) : m Term := do
+  return stringToStrLit (<- nameToString n)
+
+end KLR.Util.Meta

--- a/KLR/Util/SexpTest.lean
+++ b/KLR/Util/SexpTest.lean
@@ -30,7 +30,6 @@ private def roundTrip [BEq a] [ToSexp a] [FromSexp a] (x : a) : Bool :=
   | .error _ => false
   | .ok z => x == z
 
-
 #guard roundTrip (HashMap.ofList [(1, 2), (3, 4)])
 
 #guard roundTrip true
@@ -55,6 +54,7 @@ deriving BEq, FromSexp, Repr, ToSexp
 -- non-named field syntax
 #guard fromSexp? (sexp% (5 7)) == .ok (Foo.mk 5 7)
 #guard !(@fromSexp? Foo _ (sexp% (5 7 8))).isOk
+#guard @fromSexp? Foo _ (sexp% ((x 5) (z 9))) == .error "No field named z in Foo"
 
 -- named field syntax
 #guard fromSexp? (sexp% ((x 5) (y 7))) == .ok (Foo.mk 5 7)
@@ -83,6 +83,8 @@ deriving BEq, FromSexp, ToSexp, Repr, Lean.ToJson, Lean.FromJson
 #guard roundTrip (A1.z 5 6)
 #guard fromSexp? (sexp% (x (n 5))) == .ok (A1.x 5)
 
+#guard (@fromSexp? A1 _ (sexp% (x (n 5) (zzz 9)))) == .error "No field named zzz in A1.x"
+
 private inductive A2 where
 | x : Nat -> A2
 | y (n : Nat)
@@ -100,7 +102,6 @@ deriving BEq, FromSexp, Repr, ToSexp
 #guard toSexp (Bar.x 5 7) == sexp% (x (n 5) (k 7))
 #guard toSexp (Bar.y (Foo.mk 5 10)) == sexp% (y (m ((x 5) (y 10))))
 #guard fromSexp? (sexp% (x (n 5) (k 7))) == .ok (Bar.x 5 7)
--- unnamed syntax
 #guard fromSexp? (sexp% (x (n 5) (k 7))) == .ok (Bar.x 5 7)
 #guard fromSexp? (sexp% (x 5 7)) == .ok (Bar.x 5 7)
 #guard roundTrip (Bar.x 5 7)


### PR DESCRIPTION
I've had several bugs with typos in names. This is especially problematic when you rename a field in Lean, but forget to update the name in text files. This change throws on unknown names.

It also introduces a small Meta library that can be a home for common patterns of metaprogramming we use, so we don't need to remember dozens of library names.

Closes #199 