### PR TITLE
fix: chained comparison should not short-circuit

### DIFF
--- a/KLR/NKI/Annotations.lean
+++ b/KLR/NKI/Annotations.lean
@@ -62,6 +62,8 @@ private def expr' (e' : Expr') : Ann Expr' :=
   | .tuple es => return .tuple (<- exprs es)
   | .access e l => return .access (<- expr e) (<- l.mapM index)
   | .binOp op l r => return .binOp op (<- expr l) (<- expr r)
+  | .conj l r => return .conj (<- expr l) (<- expr r)
+  | .disj l r => return .disj (<- expr l) (<- expr r)
   | .ifExp c t f => return .ifExp (<- expr c) (<- expr t) (<- expr f)
   | .call f args kws => return .call (<- expr f) (<- exprs args) (<- kws.mapM keyword)
   termination_by sizeOf e'

--- a/KLR/NKI/Basic.lean
+++ b/KLR/NKI/Basic.lean
@@ -48,6 +48,7 @@ inductive Value where
   | tensor (shape : List Nat) (dtype : String)  -- TODO use Core Dtype
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
+-- Note: land, lor do not short-circuit (see conj, disj below)
 @[serde tag = 2]
 enum BinOp where
   -- logical
@@ -67,6 +68,7 @@ structure Expr where
   pos : Pos
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
+-- Note: conj and disj are short-circuit operators
 @[serde tag = 4]
 inductive Expr' where
   | value (value : Value)
@@ -74,6 +76,8 @@ inductive Expr' where
   | tuple (elements : List Expr)
   | access (expr : Expr) (indices : List Index)
   | binOp (op : BinOp) (left right : Expr)
+  | conj (left right : Expr)
+  | disj (left right : Expr)
   | ifExp (test tru fls : Expr)
   | call (f: Expr) (args: List Expr) (keywords : List Keyword)
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp


### PR DESCRIPTION
In Python, a chained comparison does not short-circuit. For example, if you write the expression:

  1 < 0 < f()

then the function f will be called. This is different from logical and/or which does short-circuit. We also have the possibility of logical and/or on tensors, which does not short-circuit. This change introduces two new expression forms `conj` and `disj` which are used to represent Python short-circuit and/or. The normal land and lor binary operator do not short-circuit. This gives us what we need to lower logical operators, tensor operators, and chained comparison.