### PR TITLE
feat: Add offset to ndarray

### DIFF
--- a/KLR/Trace/FromNKI.lean
+++ b/KLR/Trace/FromNKI.lean
@@ -56,6 +56,11 @@ instance [FromNKI a] [FromNKI b] : FromNKI (Sum a b) where
       | .ok b => return .inr b
       | .error e => throw s!"cannot convert to either type in sum: {e}"
 
+instance [FromNKI a] [FromNKI b] : FromNKI (a × b) where
+  fromNKI?
+  | .tuple [x, y] => do return (<- fromNKI? x, <- fromNKI? y)
+  | _ => throw "expecting 2-tuple"
+
 instance : FromNKI Term := ⟨ .ok ⟩
 
 instance : FromNKI Expr where

--- a/KLR/Trace/Term.lean
+++ b/KLR/Trace/Term.lean
@@ -505,10 +505,14 @@ nki ndarray
   (shape : Shape)
   (dtype : Dtype)
   (buffer : Option Memory := none)
-  (name : Option String := none) := do
+  (name : Option String := none)
+  (address : Option (Nat × Nat)) := do
     let memory := buffer.getD .sbuf
     let (parSize, freeSize) := Address.defaultSize shape dtype
-    let address := { memory, parSize, freeSize : Address }
+    let (parOffset, freeOffset) := match address with
+    | some (par, free) => (some par, some free)
+    | none => (none, none)
+    let address := { memory, parSize, freeSize, parOffset, freeOffset : Address }
     let name := name.getD "tensor"
     let tensor <- TensorName.make name dtype shape address
     return .expr (.value $ .access (.simple tensor)) (.tensor dtype shape)


### PR DESCRIPTION
Add support for offset for ndarray
``` python
def foo(a, a_tile):
  a_tile = nl.ndarray(a.shape, a.dtype, offset=(42,42))
  nisa.memset(dst=a_tile, name="foo", value=88.3, dtype=np.float32)
```
produces the following KLR
```
body := [KLR.Core.Stmt.oper
             (KLR.Core.Operator.memSet
               { dst := KLR.Core.TensorRef.abstract
                          (KLR.Core.Access.pattern
                            { tensor := { name := "tensor",
                                          dtype := KLR.Core.Dtype.float32,
                                          shape := { parDim := 10, freeDims := [10] },
                                          address := { memory := KLR.Core.Memory.sbuf,
                                                       parSize := 10,
                                                       freeSize := 40,
                                                       parOffset := some 42,
                                                       freeOffset := some 42 },
                                          freeElements := 10,
                                          parWF := _,
                                          freeWF := _ },
                              parNum := 10,
                              freePattern := [{ step := 1, num := 10 }],
                              offset := 0 }),
                 value := KLR.Core.Immediate.float 88.300003,
                 dtype := KLR.Core.Dtype.float32,
                 engine := KLR.Core.Engine.unassigned })
```