### PR TITLE
feat: set names of input tensors

### DIFF
--- a/KLR/NKI/Basic.lean
+++ b/KLR/NKI/Basic.lean
@@ -45,7 +45,7 @@ inductive Value where
   | int (value : Int)
   | float (value : Float)
   | string (value : String)
-  | tensor (shape : List Nat) (dtype : String)  -- TODO use Core Dtype
+  | tensor (shape : List Nat) (dtype : String) (name : Option String)
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 -- Note: land, lor do not short-circuit (see conj, disj below)

--- a/KLR/NKI/Pretty.lean
+++ b/KLR/NKI/Pretty.lean
@@ -39,7 +39,8 @@ instance : ToFormat Value where
   | .int i => format i
   | .float f => format f
   | .string s => .bracket "\"" s "\""
-  | .tensor shape dty => abracket (format shape ++ "," ++ dty)
+  | .tensor shape dty name =>
+    abracket (format shape ++ "," ++ dty ++ "," ++ format name)
 
 instance : ToFormat BinOp where
   format op :=

--- a/KLR/NKI/Simplify.lean
+++ b/KLR/NKI/Simplify.lean
@@ -57,7 +57,7 @@ private def value : Python.Const -> Simplify Value
   | .float f => return .float f
   | .string s => return .string s
   | .ellipsis => throw "invalid use of ellipsis"
-  | .tensor s dty => return .tensor s dty
+  | .tensor s dty => return .tensor s dty none
 
 /-
 # Operator Simplification


### PR DESCRIPTION
This change sets the name of input tensors to match the formal parameters of the top-level kernel they are applied to.