### PR TITLE
refactor: do not use Core.Expr in Trace.Term

### DIFF
--- a/KLR/NKI/Annotations.lean
+++ b/KLR/NKI/Annotations.lean
@@ -60,6 +60,7 @@ private def expr' (e' : Expr') : Ann Expr' :=
   | .value v => return .value v
   | .var n => return .var (<- checkName n)
   | .tuple es => return .tuple (<- exprs es)
+  | .list es => return .list (<- exprs es)
   | .access e l => return .access (<- expr e) (<- l.mapM index)
   | .binOp op l r => return .binOp op (<- expr l) (<- expr r)
   | .conj l r => return .conj (<- expr l) (<- expr r)

--- a/KLR/NKI/Basic.lean
+++ b/KLR/NKI/Basic.lean
@@ -74,6 +74,7 @@ inductive Expr' where
   | value (value : Value)
   | var (name : Name)
   | tuple (elements : List Expr)
+  | list (elements : List Expr)
   | access (expr : Expr) (indices : List Index)
   | binOp (op : BinOp) (left right : Expr)
   | conj (left right : Expr)
@@ -158,7 +159,11 @@ structure Fun where
   source : String
   body : List Stmt
   args : List Param
-  deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
+  deriving FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
+
+-- Names are fully qualified and unique
+instance : BEq Fun where
+  beq l r := l.name == r.name
 
 @[serde tag = 14]
 structure Arg where

--- a/KLR/NKI/Pretty.lean
+++ b/KLR/NKI/Pretty.lean
@@ -22,6 +22,9 @@ open Std
 private def abracket (f : Format) : Format :=
   .bracket "<" f ">"
 
+private def sbracket (f : Format) : Format :=
+  .bracket "[" f "]"
+
 private def spaces [ToFormat a] (l : List a) : Format :=
   .joinSep l " "
 
@@ -60,6 +63,7 @@ private def expr' (e : Expr') (nested : Bool := false) : Format :=
   | .value v => format v
   | .var n => n.toString
   | .tuple es => parens (.joinSep (es.map expr) ",")
+  | .list es => sbracket (.joinSep (es.map expr) ",")
   | .access e i => expr e ++ sqArgs (i.map index)
   | .binOp op l r => parens $ spaces [expr l, format op, expr r]
   | .conj l r => parens (expr l true ++ " and " ++ expr r true)

--- a/KLR/NKI/Simplify.lean
+++ b/KLR/NKI/Simplify.lean
@@ -152,8 +152,8 @@ private def expr' (e' : Python.Expr') : Simplify Expr' :=
   | .const c => return .value (<- value c)
   | .name s _ => return .var s.toName
   | .attr e id _ => return .var (.str (<- letBind (<- expr e)) id)
-  | .tuple l _
-  | .list l _ => return .tuple (<- exprs l)
+  | .tuple l _ => return .tuple (<- exprs l)
+  | .list l _ => return .list (<- exprs l)
   | .subscript e ndx _ => return .access (<- expr e) (<- indexes ndx)
   | .slice .. => throw "invalid use of slice"
   | .boolOp op l => return (<- booleanOp op (<- exprs l)).expr

--- a/KLR/Trace/Builtin.lean
+++ b/KLR/Trace/Builtin.lean
@@ -83,10 +83,10 @@ def module (name : Name) : Name × Term :=
   (name, .module name)
 
 def const_var (name: Name) : Name × Term :=
-  (name, .expr (.value $ .var name.toString))
+  (name, .var name)
 
 def const_int (name: Name) (i : Int) : Name × Term :=
-  (name, .expr (.value $ .int i))
+  (name, .int i)
 
 -- Type of builtin functions; since these are called from python,
 -- they take a list of positional argument and a list of keyword

--- a/KLR/Trace/ISA.lean
+++ b/KLR/Trace/ISA.lean
@@ -128,7 +128,7 @@ nki builtin.isa.nc_transpose
   | .pe =>
     let N := data.shapePure.freeDims.getLast!
     let id : TensorRef := <- match <- lookup_global? (.num `identity 0) with
-    | some (.expr (.value (.access acc))) => return .abstract acc
+    | some (.access acc) => return .abstract acc
     | some _ => throw "identity has wrong type"
     | none => throw "identity not defined"
     let idName <- match id with

--- a/KLR/Trace/Lang.lean
+++ b/KLR/Trace/Lang.lean
@@ -39,7 +39,7 @@ nki builtin.lang.ndarray
     let name <- tensorName name
     let address := { name, memory, parSize, freeSize, parOffset, freeOffset : Address }
     let tensor <- TensorName.make name dtype shape address
-    return .expr (.value $ .access (.simple tensor))
+    return .access (.simple tensor)
 
 nki builtin.lang.par_dim (t : Term) := do
   warn "par_dim is deprecated"
@@ -74,7 +74,7 @@ nki builtin.lang.load
   (mask : Term := .none)
   (dtype : Option Dtype := none) := do
   warn "load is not supported"
-  return .expr (.value (.access src))
+  return .access src
 
 nki builtin.lang.store (dst : Access) (src : Access) := do
   warn "store is not supported"
@@ -86,4 +86,4 @@ nki builtin.lang.copy (src : Access) (dst : Access) := do
 
 nki builtin.lang.transpose (src : Access) := do
   warn "transpose is not supported"
-  return .expr (.value (.access src))
+  return .access src

--- a/KLR/Trace/Python.lean
+++ b/KLR/Trace/Python.lean
@@ -27,29 +27,29 @@ open Core
 
 nki builtin.op.negate (t : Term) := do
   match t with
-  | (x : Int) => return x.neg
-  | (x : Float) => return x.neg
+  | .int x => return .int x.neg
+  | .float x => return .float x.neg
   | _ => throw "cannot negate values of this type"
 
 nki builtin.op.not (t : Term) := do
-  t.isFalse
+  return .bool t.isFalse
 
 nki builtin.op.invert (t : Term) := do
   let i : Int <- fromNKI? t
-  return i.toInt32.complement.toInt
+  return .int i.toInt32.complement.toInt
 
 nki builtin.python.slice (b : Int) (e : Int) (s : Int) := do
   return .slice b e s
 
 nki builtin.python.len (t : Term) := do
   match t with
-  | .tuple l | .list l => return .expr (.value (.int l.length))
+  | .tuple l | .list l => return .int l.length
   | _ => throw "invalid argument"
 
 -- TODO: should take arbitrary number of arguments and work on more types
 nki builtin.python.min (a : Term) (b : Term) := do
   match a, b with
-  | .expr (.value (.int a)), .expr (.value (.int b)) => return .int (min a b)
+  | .int a, .int b => return .int (min a b)
   | _, _ => throw "invalid arguments"
 
 
@@ -59,5 +59,5 @@ Python math library
 
 nki math.gcd (a : Term) (b : Term) := do
   match a, b with
-  | (x : Int), (y : Int) => return Int.ofNat (Int.gcd x y)
+  | .int x, .int y => return .int (Int.ofNat $ Int.gcd x y)
   | _, _ => throw "gcd not avaliable for these types"


### PR DESCRIPTION
This changes the Term type to be more independent of the Core types.