### PR TITLE
feat: implement access pattern as an attribute of Access

### DIFF
--- a/KLR/Trace/Term.lean
+++ b/KLR/Trace/Term.lean
@@ -444,6 +444,7 @@ def Term.attr (t : Term) (id : String) : Trace Term :=
       | "offset" => offset a
       | "pattern" => pattern a
       | "reshape" => return .builtin `builtin.access.reshape t
+      | "ap" => return .builtin `builtin.access.ap t
       | _ => throw s!"unsupported attribute {id} (type is tensor access)"
   | _ => throw s!"unsupported attribute {id}"
 where
@@ -504,6 +505,31 @@ nki builtin.access.reshape
   let shape <- Shape.fromList shape
   let t <- TensorName.make name dtype shape tensor.address
   return .access (.simple t)
+
+-- TODO: do we need to handle nesting here?
+nki builtin.access.ap
+    (self : Access)
+    (par_pattern : List (Int × Nat))
+    (free_pattern : List (Int × Nat))
+    (par_offset : Nat := 0)
+    (free_offset : Nat := 0) := do
+  match self with
+  | .simple t =>
+      let parNum <- match par_pattern with
+        | [] => throw "no partition pattern specified"
+        | [(1, count)] => pure count
+        | [(_,_)] => throw "partition step size must be 1"
+        | _ => throw "partition pattern must be 1 dimensional"
+      let freePattern := free_pattern.map fun (s,c) => Core.APPair.mk s c
+      let ap : Core.AccessPattern := {
+        tensor := t
+        parNum
+        freePattern
+        parOffset := par_offset
+        freeOffset := free_offset
+      }
+      return .access (.pattern ap)
+  | _ => throw "cannot specify an access pattern on an already indexed tensor"
 
 /-
 # Static environment of builtins


### PR DESCRIPTION
Introduce a new syntactic sugar which allows an access pattern to be specified with `t.ap(...)`.