### PR TITLE
fix: support python 3.13

### DIFF
--- a/interop/klr/frontend.h
+++ b/interop/klr/frontend.h
@@ -9,11 +9,6 @@ Authors: Paul Govereau, Sean McLaughlin
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-static_assert(
-    PY_MAJOR_VERSION == 3 &&
-    PY_MINOR_VERSION >= 9 &&
-    PY_MINOR_VERSION <= 12,
-    "Unsupported Python Version");
 
 #if PY_MINOR_VERSION == 9
 #define Py_IsNone(x) ((x) == Py_None)

--- a/interop/klr/peg_parser/compat.c
+++ b/interop/klr/peg_parser/compat.c
@@ -3,6 +3,11 @@ Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 */
 
+// Forward declare private APIs that used to be in public headers, but later moved to internal headers
+Py_ssize_t _PyUnicode_ScanIdentifier(PyObject *); // hidden in https://github.com/python/cpython/commit/8a73b57b
+PyObject* _PyUnicode_DecodeUnicodeEscapeInternal(const char *, Py_ssize_t, const char *, Py_ssize_t *, const char **); // hidden in https://github.com/python/cpython/commit/d8c5d76d
+PyObject* _PyBytes_DecodeEscape(const char *, Py_ssize_t, const char *, const char **); // hidden in https://github.com/python/cpython/commit/7d41ead9
+
 // These functions were introduced in Python 3.10 and are used by the parser.
 #if PY_MINOR_VERSION < 10
 static inline PyObject *_Py_NewRef(PyObject *obj) {
@@ -21,6 +26,8 @@ static PyObject *_PyImport_GetModuleAttrString(const char *modname,
   Py_DECREF(mod);
   return result;
 }
+#else
+PyObject* _PyImport_GetModuleAttrString(const char *, const char *); // hidden in https://github.com/python/cpython/commit/2e92edbf
 #endif
 
 // An alternate implementation of PyArena which uses our region allocator.

--- a/interop/klr/peg_parser/pegen.c
+++ b/interop/klr/peg_parser/pegen.c
@@ -1148,7 +1148,7 @@ static PyObject *_PyPegen_new_identifier(Parser *p, const char *n) {
       goto error;
     }
     PyObject *args[2] = {form, id};
-    id2 = _PyObject_FastCall(p->normalize, args, 2);
+    id2 = PyObject_Vectorcall(p->normalize, args, 2, NULL);
     Py_DECREF(id);
     Py_DECREF(form);
     if (!id2) {

--- a/interop/pyproject.toml
+++ b/interop/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["trainium", "tpu", "pallas", "triton", "gpu"]
 dependencies = [
   "numpy",
 ]
-requires-python = ">= 3.9, < 3.13"
+requires-python = ">= 3.9"
 
 [project.urls]
 Repository = "https://github.com/leanprover/KLR"


### PR DESCRIPTION
Python 3.13 has been out for months. We should support it.

The difficulty came from the peg_parser code we lifted from Python 3.12 that makes use of "internal" Python C-APIs. It was pretty simple to fix these up so they build again.

CONTROVERSIALLY: I'm no longer stating a max python version we support. cibuildwheel is now providing wheels for 3.13 and 3.14. If anyone feels strongly that we should declare a max version, I'll put it back.