### PR TITLE
shared constants

### DIFF
--- a/KLR/Core/Tensor.lean
+++ b/KLR/Core/Tensor.lean
@@ -58,7 +58,38 @@ inductive Dtype where
     | .int8 | .int16 | .int64 | .int32
     | .uint8 | .uint16 | .uint32 | .uint64 => true
     | _ => false
+    @[computed_field]
+    toTensorLibDtype : Dtype -> TensorLib.Dtype
+    | .uint8 => TensorLib.Dtype.uint8
+    | .uint16 => TensorLib.Dtype.uint16
+    | .uint32 => TensorLib.Dtype.uint32
+    | .uint64 => TensorLib.Dtype.uint64
+    | .int8 => TensorLib.Dtype.int8
+    | .int16 => TensorLib.Dtype.int16
+    | .int32 => TensorLib.Dtype.int32
+    | .int64 => TensorLib.Dtype.int64
+    | .float16 => TensorLib.Dtype.float32
+    | .float32 => TensorLib.Dtype.float32
+    | .float32r => TensorLib.Dtype.float32
+    | .bfloat16 => TensorLib.Dtype.float32
+    | _ => TensorLib.Dtype.float32
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
+
+namespace Dtype
+
+def fromTensorLibDtype : TensorLib.Dtype -> Dtype
+  | TensorLib.Dtype.uint8 => .uint8
+  | TensorLib.Dtype.uint16 => .uint16
+  | TensorLib.Dtype.uint32 => .uint32
+  | TensorLib.Dtype.uint64 => .uint64
+  | TensorLib.Dtype.int8 => .int8
+  | TensorLib.Dtype.int16 => .int16
+  | TensorLib.Dtype.int32 => .int32
+  | TensorLib.Dtype.int64 => .int64
+  | TensorLib.Dtype.float32 => .float32
+  | _ => .float32
+
+end Dtype
 
 /-
 A tensor shape is a list of the sizes of each dimension of the tensor. By

--- a/KLR/Trace/FromNKI.lean
+++ b/KLR/Trace/FromNKI.lean
@@ -115,6 +115,11 @@ instance : FromNKI String where
     | .string s => return s
     | _ => throw "expecting string"
 
+instance : FromNKI TensorLib.Tensor where
+  fromNKI?
+  | .tensor t => return t
+  | _ => throw "expecting a tensor"
+
 -- TODO: when new NKI API is settled, rewrite is a nicer way
 instance : FromNKI Dtype where
   fromNKI?

--- a/KLR/Trace/Lang.lean
+++ b/KLR/Trace/Lang.lean
@@ -83,7 +83,3 @@ nki builtin.lang.store (dst : Access) (src : Access) := do
 nki builtin.lang.copy (src : Access) (dst : Access) := do
   warn "copy is not supported"
   return .none
-
-nki builtin.lang.transpose (src : Access) := do
-  warn "transpose is not supported"
-  return .access src

--- a/KLR/Trace/Python.lean
+++ b/KLR/Trace/Python.lean
@@ -61,6 +61,7 @@ private partial def termStr : Term -> Trace String
   | .pointer .. => return "<ptr>"
   | .mgrid => return "<mgrid>"
   | .mgItem .. => return "<mgrid_item>"
+  | .tensor .. => return "<tensor>"
 
 nki builtin.python.print (t : Term) := do
   message (<- termStr t)

--- a/KLR/Trace/Tensor.lean
+++ b/KLR/Trace/Tensor.lean
@@ -1,0 +1,117 @@
+/-
+Copyright KLR Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import KLR.Core
+import KLR.Trace.ISA
+
+namespace KLR.Trace
+open Core
+
+def iterUnOp (t : TensorLib.Tensor) (f : ByteArray -> ByteArray) : Trace TensorLib.Tensor := do
+  let mut dst := ByteArray.emptyWithCapacity t.data.size
+  let dt := t.dtype
+  for idx in t.shape.belist do
+    let v := <- t.getDimIndex idx
+    let v := f v
+    dst := dst.append v
+  return {dtype := dt, shape := t.shape, data := dst}
+
+def iterBinOp (l r : TensorLib.Tensor) (f : ByteArray -> ByteArray -> ByteArray) : Trace TensorLib.Tensor := do
+  if l.shape != r.shape then throw s!"tensors have different shapes {l.shape} {r.shape}"
+  let mut dst := ByteArray.emptyWithCapacity l.data.size
+  let dt := l.dtype
+  for idx in l.shape.belist do
+    let vl := <- l.getDimIndex idx
+    let vr := <- r.getDimIndex idx
+    let v := f vl vr
+    dst := dst.append v
+  return {dtype := dt, shape := l.shape, data := dst}
+
+def tensorScalarOpByteArray (op : BinOp) (l : TensorLib.Tensor) (r : ByteArray) : Trace Term := do
+  let dt := l.dtype
+  match op with
+  | .add => return .tensor $ <- iterUnOp l (fun x => dt.add! x r)
+  | .sub => return .tensor $ <- iterUnOp l (fun x => dt.sub! x r)
+  | .mul => return .tensor $ <- iterUnOp l (fun x => dt.mul! x r)
+  | .div => return .tensor $ <- iterUnOp l (fun x => dt.div! x r)
+  | _ => throw "unsupported scalar operator on tensor"
+
+def tensorOpScalarFloat (op : BinOp) (l : TensorLib.Tensor) (r : Float) : Trace Term := do
+  let dt := l.dtype
+  let br := <- dt.byteArrayOfFloat32 r.toFloat32
+  tensorScalarOpByteArray op l br
+
+def tensorOpScalarInt (op : BinOp) (l : TensorLib.Tensor) (r : Int) : Trace Term := do
+  let dt := l.dtype
+  let br := <- dt.byteArrayOfInt r
+  tensorScalarOpByteArray op l br
+
+nki builtin.lang.transpose (src : Access) := do
+  warn "transpose is not supported"
+  return .access src
+
+nki builtin.lang.zeros (shape: Shape) (dtype: Dtype) := do
+  let tlShape := TensorLib.Shape.mk shape.toList
+  let tlDtype := dtype.toTensorLibDtype
+  let tensor := TensorLib.Tensor.zeros tlDtype tlShape
+  return .tensor tensor
+
+nki builtin.lang.arange
+ (start : Nat)
+ (stop : Nat)
+ (step : Nat := 1)
+ (dtype : Dtype := .float32) := do
+  let tlDtype := dtype.toTensorLibDtype
+  let cnt := (stop - start + step - 1).div  step
+  let tlShape := TensorLib.Shape.mk [cnt]
+  let values := List.range cnt |>.map (fun i => start + i * step)
+  let mut data := ByteArray.emptyWithCapacity $ cnt * tlDtype.itemsize
+  for v in values do
+    let bytes <- tlDtype.byteArrayOfNat v
+    data := data.append bytes
+  return .tensor {dtype := tlDtype, shape := tlShape, data := data}
+
+nki builtin.lang.identity
+  (N : Nat)
+  (dtype : Dtype := .float32) := do
+  let tlDtype := dtype.toTensorLibDtype
+  let tlShape := TensorLib.Shape.mk [N, N]
+  let mut data := ByteArray.emptyWithCapacity (N * N * tlDtype.itemsize)
+  for i in [0:N] do
+      for j in [0:N] do
+        let value : Nat := if i == j then 1 else 0
+        let bytes <- tlDtype.byteArrayOfNat value
+        data := data.append bytes
+  return .tensor { dtype := tlDtype, shape := tlShape, data := data }
+
+nki builtin.lang.shared_constant
+  (t : TensorLib.Tensor)
+  (dtype : Option Dtype := none) := do
+  let name <- genName
+  let dtype := Dtype.fromTensorLibDtype t.dtype
+  let shape := Shape.mk t.shape.val.head! t.shape.val.tail!
+  let (parSize, freeSize) := Address.defaultSize shape dtype
+  let addr := {
+    name := name.toString,
+    memory := .hbm,
+    parSize, freeSize,
+    parOffset := none, freeOffset := none : Address
+  }
+  let tensorName <- TensorName.make name.toString dtype shape addr
+  modify fun s => { s with
+    sharedConstants := s.sharedConstants.push (name.toString, t)
+  }
+  return .access (.simple tensorName)

--- a/KLR/Trace/Types.lean
+++ b/KLR/Trace/Types.lean
@@ -106,6 +106,7 @@ inductive Term where
   | access   : Core.Access -> Term
   | tuple    : List Term -> Term
   | list     : Array Term -> Term
+  | tensor   : TensorLib.Tensor -> Term
   -- indexing
   | ellipsis : Term
   | slice    : Option Int -> Option Int -> Option Int -> Term
@@ -371,6 +372,14 @@ partial def isTrue (t : Term) : Trace Bool := do
   | .pointer ..
   | .mgrid ..
   | .mgItem .. => return true
+  | .tensor t =>
+    if t.shape.count == 0 then
+     return t.toList.toBool
+    else if t.shape.count > 1 then
+     throw "The truth value of an array with more than one element is ambiguous"
+    else
+     throw "The truth value of an empty array is ambiguous"
+
 
 def isFalse (t : Term) : Trace Bool :=
   return not (<- t.isTrue)


### PR DESCRIPTION
Traces the following kernel:
``` python
def f():
  c = nl.shared_constant(nl.identity(42, np.int8) + nl.identity(42, np.int8) + 1)
  return c
```
Trace produced:
```
{ name := "test.f",
  inputs := [],
  outputs := [{ name := "tmp.2",
                dtype := KLR.Core.Dtype.int8,
                shape := { parDim := 42, freeDims := [42] },
                address := { name := "tmp.2",
                             memory := KLR.Core.Memory.hbm,
                             parSize := 42,
                             freeSize := 42,
                             parOffset := none,
                             freeOffset := none },
                freeElements := 42,
                parWF := _,
                freeWF := _ }],
  bodies := [[
                << id_stuff>>
                { line := 0, column := 0, lineEnd := none, columnEnd := none }]],
  sharedConstants := [{ name := "tmp.1", fileName := "./shared_constants/tmp.1.npy" },
                      { name := "tmp.2", fileName := "./shared_constants/tmp.2.npy" }] }
```