### PR TITLE
fix: Python extension no longer sets LEAN_ABORT_ON_PANIC

### DIFF
--- a/KLR/Compile.lean
+++ b/KLR/Compile.lean
@@ -94,9 +94,16 @@ def frontend_trace (srcPythonAstFileName dstKlrFileName : String) : IO String :=
 @[export klr_frontend_hello]
 def frontend_hello : IO UInt32 := do
   IO.println ("hello from Lean")
-  return 0
+  return 123
 
--- for testing FFI error handling
-@[export klr_frontend_fail]
-def frontend_fail : IO UInt32 := do
-  throw (IO.userError "frontend_fail 😵")
+-- for testing FFI error handling when Lean code does a throw
+@[export klr_frontend_throw]
+def frontend_throw : IO UInt32 := do
+  throw (IO.userError "frontend_throw 🙁")
+  return 123
+
+-- for testing FFI error handling when Lean code does a panic!
+@[export klr_frontend_panic]
+def frontend_panic : IO UInt32 := do
+  panic! "frontend_panic 😵"
+  return 123

--- a/interop/klr/frontend.c
+++ b/interop/klr/frontend.c
@@ -198,7 +198,8 @@ static PyMethodDef methods[] = {
 #ifdef IS_NKI_REPO
   {"_klr_trace", klr_trace, METH_VARARGS, "Trace Python to KLR"},
   {"_lean_ffi_hello", lean_ffi_hello, METH_NOARGS, "Sanity check of Lean FFI"},
-  {"_lean_ffi_fail", lean_ffi_fail, METH_NOARGS, "Sanity check of Lean FFI error handling"},
+  {"_lean_ffi_throw", lean_ffi_throw, METH_NOARGS, "Sanity check of Lean FFI error handling"},
+  {"_lean_ffi_panic", lean_ffi_panic, METH_NOARGS, "Sanity check of Lean FFI error handling"},
 #endif
   {NULL, NULL, 0, NULL}
 };

--- a/interop/klr/frontend.h
+++ b/interop/klr/frontend.h
@@ -89,6 +89,7 @@ PyObject* klr_trace(PyObject *self, PyObject *args);
 
 // Sanity tests
 PyObject* lean_ffi_hello(PyObject *self, PyObject *args);
-PyObject* lean_ffi_fail(PyObject *self, PyObject *args);
+PyObject* lean_ffi_throw(PyObject *self, PyObject *args);
+PyObject* lean_ffi_panic(PyObject *self, PyObject *args);
 
 #endif // IS_NKI_REPO


### PR DESCRIPTION
### Issue
The Python extension was aborting when it hit this branch:
https://github.com/leanprover/KLR/blob/558ebcf54988c38d14e263065868e400b587f804/KLR/Core/Indexing.lean#L617

But `panic!` in Lean isn't necessarily meant to be fatal. I'd assumed that it was like Rust's `panic!`, and meant "unrecoverable error", when I added this code to the Python extension:
https://github.com/leanprover/KLR/blob/7e7bc1ee070da01db8bd951f1b371e2d56829278/interop/klr/klr_ffi.c#L42-L44

But if you look at how the Lean docs talk about `panic!`, you can see how execution will continue. From the docs for [List.head!](https://lean-lang.org/doc/reference/latest///Basic-Types/Linked-Lists/#List___head___-next):
> If the list is empty, panics and returns default.

### Changes
- Python extension no longer does LEAN_ABORT_ON_PANIC
- Add FFI function that panics, so we can test behavior from Python extension