### PR TITLE
feat: add support for tuple and keyword expansion in gather step

### DIFF
--- a/KLR/Python.lean
+++ b/KLR/Python.lean
@@ -112,11 +112,12 @@ inductive Expr' where
   | compare (left : Expr) (ops : List CmpOp) (comparators : List Expr)
   | ifExp (test body orelse : Expr)
   | call (f: Expr) (args: List Expr) (keywords : List Keyword)
+  | starred (e : Expr) (ctx : Ctx)
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 @[serde tag = 9]
 structure Keyword where
-  id : String
+  id : Option String  -- none means **value from Python parser
   value : Expr
   pos : Pos
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp

--- a/Main.lean
+++ b/Main.lean
@@ -186,7 +186,7 @@ def info (p : Parsed) : IO UInt32 := do
     IO.println s!"AST summary for Python Core kernel {kernel.entry}"
     let fs := String.intercalate "," $ kernel.funcs.map fun f => f.name
     IO.println s!"Source Functions: {fs}"
-    let gs := String.intercalate "," $ kernel.globals.map fun kw => kw.id
+    let gs := String.intercalate "," $ kernel.globals.map fun kw => kw.id.get!
     IO.println s!"Globals: {gs}"
   | .nki kernel =>
     IO.println s!"AST summary for NKI kernel {kernel.entry}"

--- a/interop/klr/ast_python_core.h
+++ b/interop/klr/ast_python_core.h
@@ -112,6 +112,7 @@ enum Python_Expr_Tag {
   Python_Expr_compare,
   Python_Expr_ifExp,
   Python_Expr_call,
+  Python_Expr_starred,
 };
 struct Python_Expr_const {
   struct Python_Const *value;
@@ -175,6 +176,10 @@ struct Python_Expr_call {
   struct Python_Expr_List *args;
   struct Python_Keyword_List *keywords;
 };
+struct Python_Expr_starred {
+  struct Python_Expr *e;
+  enum Python_Ctx ctx;
+};
 struct Python_Expr_ {
   enum Python_Expr_Tag tag;
   union {
@@ -192,6 +197,7 @@ struct Python_Expr_ {
     struct Python_Expr_compare compare;
     struct Python_Expr_ifExp ifExp;
     struct Python_Expr_call call;
+    struct Python_Expr_starred starred;
   };
 };
 

--- a/interop/klr/gather.c
+++ b/interop/klr/gather.c
@@ -776,6 +776,13 @@ static struct Python_Expr* expr(struct state *st, struct _expr *python) {
       break;
     }
 
+    case Starred_kind: {
+      e->tag = Python_Expr_starred;
+      e->starred.e = expr(st, python->v.Starred.value);
+      e->name.ctx = context(python->v.Starred.ctx);
+      break;
+    }
+
     default:
       syntax_error(st, "unsupported expression");
       res = NULL;
@@ -822,7 +829,11 @@ static struct Python_Keyword* keyword(struct state *st, keyword_ty python) {
   struct Python_Keyword *kw = region_alloc(st->region, sizeof(*kw));
   Pos(kw->pos, python);
 
-  kw->id = py_strdup(st, python->arg);
+  // NULL means **kwarg
+  if (python->arg == NULL)
+    kw->id = NULL;
+  else
+    kw->id = py_strdup(st, python->arg);
   kw->value = expr(st, python->value);
   if (!kw->id || !kw->value)
     return NULL;


### PR DESCRIPTION
This change adds support for parsing tuple expansion (*args) and keyword expansion (**kwargs). These features are not yet implemented, this only adds abstract syntax and parsing support.