### PR TITLE
fix: gather supports numpy.ndarray

### DIFF
--- a/interop/klr/gather.c
+++ b/interop/klr/gather.c
@@ -251,11 +251,10 @@ static struct Python_Expr* const_expr(struct state *st, PyObject *obj) {
     PyTypeObject *t = Py_TYPE(obj);
     if (!t) return NULL;
 
-    // Tensor is type for PyTorch tensors, ShapedArray is type for JAX tensors
-    if (strcmp(t->tp_name, "tensor") != 0 &&
-        strcmp(t->tp_name, "ndarray") != 0 &&
-        strcmp(t->tp_name, "Tensor") != 0 &&
-        strcmp(t->tp_name, "ShapedArray") != 0)
+    if (strcmp(t->tp_name, "tensor" /*nki*/) != 0 &&
+        strcmp(t->tp_name, "numpy.ndarray" /*numpy*/) != 0 &&
+        strcmp(t->tp_name, "Tensor" /*PyTorch*/) != 0 &&
+        strcmp(t->tp_name, "ShapedArray" /*JAX*/) != 0)
       return NULL;
 
     PyObject *shape = PyObject_GetAttrString(obj, "shape");


### PR DESCRIPTION
numpy.ndarray was being rejected. It's `tp_name` is "numpy.ndarray" (we were checking "ndarray"). Other tensor types we support do not have a "." in their tp_name. (whether or not there's a "." isn't affected by python version, I tested 3.9-3.13).  Maybe we shouldn't be checking type names, maybe we should just "duck type" and check if they have a shape and dtype? We can look into that in the future... this simple change unblocks numpy.