### PR TITLE
Fix incorrect logic of greater than operator

### DIFF
--- a/KLR/Trace/Term.lean
+++ b/KLR/Trace/Term.lean
@@ -196,7 +196,7 @@ private def binop' (op : BinOp) (l r : Term) : Trace Term := do
   | .ne => return .bool (l != r)
   | .lt => return .bool (<- termLt l r)
   | .le => return .bool (l == r || (<- termLt l r))
-  | .gt => return .bool (not (l == r && not (<- termLt l r)))
+  | .gt => return .bool ((not (l == r)) && (not (<- termLt l r)))
   | .ge => return .bool (not (<- termLt l r))
   -- arithmetic / bitwise
   | _ => termOp op l r


### PR DESCRIPTION
The logic for lowering grater than with lt is faulty because it was missing brackets.