### PR TITLE
fix: consistent naming of "psum"

### DIFF
--- a/KLR/Core/Pretty.lean
+++ b/KLR/Core/Pretty.lean
@@ -43,7 +43,7 @@ instance : ToFormat Memory where
   format
   | .hbm => "hbm"
   | .sbuf => "sbuf"
-  | .pmem => "pmem"
+  | .psum => "psum"
   | .reg  => "reg"
 
 instance : ToFormat Dtype where

--- a/KLR/KLR/Basic.lean
+++ b/KLR/KLR/Basic.lean
@@ -32,7 +32,7 @@ inductive Engine where
 
 -- Memory types
 inductive Memory where
-  | hbm | sbuf | pmem
+  | hbm | sbuf | psum
   deriving Repr, BEq
 
 /-

--- a/interop/neuronxcc/nki/language/__init__.py
+++ b/interop/neuronxcc/nki/language/__init__.py
@@ -10,7 +10,7 @@ def ndarray(shape, dtype, buffer=None, name=''):
   elif buffer == nki.language.sbuf:
     buffer = sbuf
   elif buffer == nki.language.psum:
-    buffer = pmem
+    buffer = psum
   else:
     assert False, "invalid buffer argument"
   return buffer.view(dtype, shape, name)

--- a/interop/test/test_memory.py
+++ b/interop/test/test_memory.py
@@ -11,7 +11,7 @@ from klr.frontend import Kernel
 def pointers():
   x = sbuf[0:128, 0:512]
   y = x[32:,:]
-  a = pmem[:64,:512]
+  a = psum[:64,:512]
   b = a[32:,:]
   sb = sbuf[:,1024:2048]
   left = sb[:,0:512]


### PR DESCRIPTION
Previously, it was called "pmem" in some places. This makes it consistent.