### PR TITLE
Feat: pass file name around and report errors with file name

### DIFF
--- a/KLR/NKI/Simplify.lean
+++ b/KLR/NKI/Simplify.lean
@@ -356,14 +356,15 @@ private def params (args : Python.Args) : Simplify (List Param) := do
   return params.reverse
 
 private def func (f : Python.Fun) : Simplify Fun :=
-  return {
-    name := f.name
-    file := "unknown"  -- TODO: fix me
-    line := f.line
-    source := f.source
-    args := <- params f.args
-    body := <- stmts f.body
-  }
+  withFile f.fileName f.line do
+    return {
+      name := f.name
+      file := f.fileName
+      line := f.line
+      source := f.source
+      args := <- params f.args
+      body := <- stmts f.body
+    }
 
 /-
 # Kernel Simplification

--- a/KLR/Python.lean
+++ b/KLR/Python.lean
@@ -194,6 +194,7 @@ def Args.all_defaults (args : Args) : List Keyword :=
 @[serde tag = 13]
 structure Fun where
   name : String
+  fileName : String
   line : Nat
   source : String
   args : Args

--- a/KLR/Trace/NKI.lean
+++ b/KLR/Trace/NKI.lean
@@ -218,7 +218,7 @@ partial def fnCall (f : Term) (args : List Expr) (kwargs : List Keyword) : Trace
       let args <- bindArgs f args kwargs
       let args <- args.mapM keyword
       args.forM fun (_,t) => checkAccess t (warnOnly := false)
-      withSrc f.line f.source $ enterFun do
+      withSrc f.file f.line f.source $ enterFun do
         args.forM fun kw => extend kw.1.toName kw.2
         match <- stmts f.body with
         | .ret t => return t

--- a/KLR/Trace/Types.lean
+++ b/KLR/Trace/Types.lean
@@ -211,7 +211,7 @@ Catch and report errors with source locations. The `withSrc` function is always
 used a function boundaries, and converts `located` errors to `formatted`
 errors.
 -/
-def withSrc (line : Nat) (source : String) (m : Trace a) : Trace a := fun s =>
+def withSrc (fileName : Option String) (line : Nat) (source : String) (m : Trace a) : Trace a := fun s =>
   let p' := s.pos
   match m { s with pos := { line := 0 } } with
   | .ok x s => .ok x { s with pos := p' }
@@ -230,7 +230,8 @@ where
                 then lines[lineno]'h
                 else "<source not available>"
     let indent := (Nat.repeat (List.cons ' ') colno List.nil).asString
-    s!"\nline {lineno + offset}:\n{line}\n{indent}^-- {err}"
+    let path := fileName.getD "unknown"
+    s!"\n{path}:{lineno + offset}:\n{line}\n{indent}^-- {err}"
 
 -- generate a fresh name using an existing name as a prefix
 def genName (name : Name := `tmp) : Trace Name :=

--- a/interop/klr/ast_python_core.h
+++ b/interop/klr/ast_python_core.h
@@ -297,6 +297,7 @@ struct Python_Args {
 
 struct Python_Fun {
   char *name;
+  char *fileName;
   u32 line;
   char *source;
   struct Python_Args *args;

--- a/interop/klr/gather.c
+++ b/interop/klr/gather.c
@@ -1233,6 +1233,7 @@ static struct Python_Fun* function(struct state *st, PyObject *f) {
 
   fn = region_alloc(st->region, sizeof(*fn));
   fn->name = name;
+  fn->fileName = st->scope.file;
   fn->line = st->scope.line_offset;
   fn->source = st->scope.src;
   fn->body = body;

--- a/interop/klr/serde_python_core.c
+++ b/interop/klr/serde_python_core.c
@@ -520,9 +520,11 @@ bool Python_Args_ser(FILE *out, struct Python_Args *x) {
 }
 
 bool Python_Fun_ser(FILE *out, struct Python_Fun *x) {
-  if (!cbor_encode_tag(out, 13, 0, 5))
+  if (!cbor_encode_tag(out, 13, 0, 6))
     return false;
   if (!String_ser(out, x->name))
+    return false;
+  if (!String_ser(out, x->fileName))
     return false;
   if (!cbor_encode_uint(out, x->line))
     return false;
@@ -1269,10 +1271,12 @@ bool Python_Fun_des(FILE *in, struct region *region, struct Python_Fun **x) {
   u8 t, c, l;
   if (!cbor_decode_tag(in, &t, &c, &l))
     return false;
-  if (t != 13 || c != 0 || l != 5)
+  if (t != 13 || c != 0 || l != 6)
     return false;
   *x = region_alloc(region, sizeof(**x));
   if (!String_des(in, region, &(*x)->name))
+    return false;
+  if (!String_des(in, region, &(*x)->fileName))
     return false;
   if (!Nat_des(in, region, &(*x)->line))
     return false;


### PR DESCRIPTION
Improves error messaging by adding file name to errors. 
E.g:
```
error:
/Users/ppotapov/work/KLR/test2.py:3:
    return A[i]
             ^-- i not found
/Users/ppotapov/work/KLR/test.py:10:
  A = f2(A)
      ^-- called from
```