### PR TITLE
chore: simpler way to call trace from python

### DIFF
--- a/interop/klr/__init__.py
+++ b/interop/klr/__init__.py
@@ -1,3 +1,51 @@
 # Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # Released under Apache 2.0 license as described in the file LICENSE.
 # Authors: Paul Govereau, Sean McLaughlin
+
+import json
+from tempfile import NamedTemporaryFile
+from typing import Optional, Sequence, Union
+
+from . import frontend
+
+
+# wrapper around kernel.specialize()
+def _specialize_kernel(
+    kernel: frontend.Kernel,
+    args: Optional[tuple] = None,
+    kwargs: Optional[dict] = None,
+    *,
+    grid: Optional[int] = None,
+    schedule: Optional[Sequence[tuple[str, Union[str, Sequence[str]]]]] = None,
+):
+    kernel.specialize(args, kwargs, grid, schedule)
+
+
+# wrapper around tracing step via KLR's Lean FFI.
+# (Using the Lean impl because it's currently more mature than the C impl).
+def _trace_kernel(
+    kernel: frontend.Kernel,
+    *,
+    dst_filepath: str,
+) -> dict:
+    """
+    Trace Python to KLIR
+
+    Returns: dict of metadata
+    """
+
+    # The current trace function needs to read in a file with the Python AST.
+    # Then it writes out a file with the final KLIR.
+
+    # So first we need to create that file with the Python AST...
+    with NamedTemporaryFile(suffix="_python_ast.klir", delete=False) as tmp:
+        python_ast_filepath = tmp.name
+    kernel._serialize_python(python_ast_filepath)
+
+    # OK. Now we can invoke trace() which writes out the final KLIR to a file...
+    metadata_json_str = frontend._klr_trace(python_ast_filepath, dst_filepath)
+
+    # trace() returned metadata as a string of JSON data.
+    # Return it as a Python dict
+    metadata = json.loads(metadata_json_str)
+    return metadata

--- a/interop/klr/frontend.c
+++ b/interop/klr/frontend.c
@@ -54,28 +54,33 @@ static void kernel_dealloc(struct kernel *self) {
 // frontend.Kernel.specialize
 // Provide arguments for kernel specialization
 static PyObject* kernel_specialize(struct kernel *self, PyObject *args_tuple) {
-  PyObject* args = NULL;
-  PyObject* kwargs = NULL;
-  PyObject* internal_kwargs = NULL;
+  PyObject* args = Py_None;     // O
+  PyObject* kwargs = Py_None;   // O
+  PyObject* grid = Py_None;     // O
+  PyObject* schedule = Py_None; // O
 
-  if (!PyArg_ParseTuple(args_tuple, "|OOO", &args, &kwargs, &internal_kwargs)) {
-      return NULL;
-  }
-
-  if (args && args != Py_None && !PyTuple_Check(args)) {
-      PyErr_SetString(PyExc_TypeError, "Invalid Argument: args argument must be a tuple");
-      return NULL;
-  }
-  if (kwargs && kwargs != Py_None && !PyDict_Check(kwargs)) {
-      PyErr_SetString(PyExc_TypeError, "Invalid Argument: kwargs argument must be a dictionary");
-      return NULL;
-  }
-  if (internal_kwargs && internal_kwargs != Py_None && !PyDict_Check(internal_kwargs)) {
-      PyErr_SetString(PyExc_TypeError, "Invalid Argument: internal_kwargs argument must be a dictionary");
+  if (!PyArg_ParseTuple(args_tuple, "|OOOO", &args, &kwargs, &grid, &schedule)) {
       return NULL;
   }
 
-  if (!specialize(self, args, kwargs, internal_kwargs))
+  if (args != Py_None && !PyTuple_Check(args)) {
+      PyErr_SetString(PyExc_TypeError, "Invalid Argument: 'args' must be a tuple");
+      return NULL;
+  }
+  if (kwargs != Py_None && !PyDict_Check(kwargs)) {
+      PyErr_SetString(PyExc_TypeError, "Invalid Argument: 'kwargs' must be a dictionary");
+      return NULL;
+  }
+  if (grid != Py_None && !PyLong_Check(grid)) {
+      PyErr_SetString(PyExc_TypeError, "Invalid Argument: 'grid' must be an int");
+      return NULL;
+  }
+  if (schedule != Py_None && !PySequence_Check(schedule)) {
+      PyErr_SetString(PyExc_TypeError, "Invalid Argument: 'schedule' must be a sequence");
+      return NULL;
+  }
+
+  if (!specialize(self, args, kwargs, grid, schedule))
     return NULL;
 
   return Py_None;

--- a/interop/klr/frontend.h
+++ b/interop/klr/frontend.h
@@ -42,7 +42,7 @@ void free_python_ast(struct _mod *m);
 
 // gather.c
 bool gather(struct kernel *k);
-bool specialize(struct kernel *k, PyObject *args, PyObject *kws, PyObject *internal_kws);
+bool specialize(struct kernel *k, PyObject *args, PyObject *kws, PyObject *grid, PyObject *schedule);
 
 // serde.c
 struct SerResult {


### PR DESCRIPTION
Currently, before you can call the Lean FFI version of trace, you need to serialize the Python AST to a file. This was leading to copy/pasted boilerplate in the tests I'm adding to the NeuronKernelInterface repo.

I added wrapper functions in `klr/__init__.py` to do that boilerplate, since boilerplate is a lot easier in python than C.

I also tweaked specialize so that extra args like `grid` are passed as actual keyword arguments, vs stuffing them all into an untyped `internal_kws` dict.  I also added a python wrapper for specialize, because it's easier to show arg names, type hints, comments etc in Python vs C.

Yes, it's a bit sloppy to just start throwing in wrapper functions, vs fixing the actual Kernel class to be nice, but this code won't live forever, and we can take these lessons to the next version...