### PR TITLE
Feat: automatically generated tensor names from ptr and ndarray should be unique

### DIFF
--- a/KLR/NKI/SimplifyOperators.lean
+++ b/KLR/NKI/SimplifyOperators.lean
@@ -54,7 +54,12 @@ private def rewriteNdarray (stmt : Stmt') : Stmt' :=
       if kws.any fun x => x.name == "name" then
        stmt
       else
-        let kws := ⟨"name", ⟨ .value $ .string x.toString, p1⟩⟩ :: kws
+        let uniqueNameCall := ⟨.call
+          ⟨.var `builtin.lang.unique_name, p1⟩
+          [⟨.value (.string x.toString), p1⟩]
+          [],
+          p1⟩
+        let kws := ⟨"name", uniqueNameCall⟩ :: kws
         .letM (.var x) ty ⟨.call ⟨.var fname, p0 ⟩ args kws, p1 ⟩
     else
       stmt

--- a/KLR/Trace/Lang.lean
+++ b/KLR/Trace/Lang.lean
@@ -107,3 +107,7 @@ nki builtin.lang.store (dst : Access) (src : Access) := do
 nki builtin.lang.copy (src : Access) (dst : Access) := do
   warn "copy is not supported"
   return .none
+
+nki builtin.lang.unique_name (name : String) := do
+  let uniqueName := <-genName name.toName
+  return .string uniqueName.toString


### PR DESCRIPTION
Allows to trace kernels like `foo`
```python
def f():
  a = hbm.view(nl.int8, (128,128))
  b = hbm.view(nl.int8, (128,128))
  builtin.isa.dma_copy(dst=a, src=b)
  builtin.isa.dma_copy(dst=b, src=a)
  return a

def foo():
  a = f()
  b = f()
  return a, b
```