### PR TITLE
feat: generate init functions for classes

### DIFF
--- a/KLR/Compile.lean
+++ b/KLR/Compile.lean
@@ -44,6 +44,7 @@ def compilePython (kernel : Python.Kernel) (outfolder : Option String) : IO Core
   w.forM IO.println
   let kernel <- KLR.NKI.annotate kernel
   let kernel <- KLR.NKI.simplifyPatterns kernel
+  let kernel <- KLR.NKI.genClasses kernel
   -- Leave in for debugging
   -- TODO use debug flags?
   --IO.println (Std.Format.pretty (Std.format kernel))

--- a/KLR/NKI.lean
+++ b/KLR/NKI.lean
@@ -16,6 +16,7 @@ limitations under the License.
 
 import KLR.NKI.Annotations
 import KLR.NKI.Basic
+import KLR.NKI.Classes
 import KLR.NKI.Patterns
 import KLR.NKI.Pretty
 import KLR.NKI.Simplify

--- a/KLR/NKI/Basic.lean
+++ b/KLR/NKI/Basic.lean
@@ -155,12 +155,13 @@ structure Param where
 
 @[serde tag = 13]
 structure Fun where
-  name : String
-  file : String
-  line : Nat
-  source : String
-  body : List Stmt
-  args : List Param
+  name : Name
+  decs : List Name := []
+  file : String := "<unknown file>"
+  line : Nat := 0
+  source : String := "<source unavailable>"
+  body : List Stmt := []
+  args : List Param := []
   deriving FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 -- Names are fully qualified and unique
@@ -169,7 +170,8 @@ instance : BEq Fun where
 
 @[serde tag = 14]
 structure Class where
-  name : String
+  name : Name
+  decs : List Name
   fields : List Keyword
   methods : List Fun
   deriving FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
@@ -186,7 +188,7 @@ structure Arg where
 
 @[serde tag = 16]
 structure Kernel where
-  entry : String
+  entry : Name
   funs : List Fun
   cls : List Class
   args : List Arg

--- a/KLR/NKI/Classes.lean
+++ b/KLR/NKI/Classes.lean
@@ -1,0 +1,178 @@
+/-
+Copyright KLR Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import KLR.Compile.Pass
+import KLR.NKI.Basic
+import KLR.Util
+
+/-
+Process class definitions
+
+This pass does two things: move class methods to the function list, and
+generate constructor and initializer functions.
+-/
+
+namespace KLR.NKI
+open Compile.Pass
+
+abbrev Cls := PassM
+
+/-
+Generate a constructor function based on the init function.
+
+If the init function has the signature
+
+  def __init__(x,y,z=1)
+
+Then the constructor will have the form:
+
+  def C(x,y,z=1):
+    self = builtin.new("C")
+    self.__init__(x,y,z)
+    return self
+
+This function will be registered under the class name, so expressions
+like `x = C(...)`, will end up calling this generated function.
+
+Note, regular projections from the class, like `C.x`m will also work since we
+move all of these to the environment.
+-/
+private def genNew (init : Fun) : Cls Fun := do
+  let name <- match init.name with
+              | .str n _ => pure n
+              | n => throw s!"internal error: invalid name for init {n}"
+  let pos := { line := 0 : Pos }
+  let var n : Expr := ⟨ .var n, pos ⟩
+  let cls := ⟨ .value (.string name.toString), pos ⟩
+  let args := init.args.map fun p => var p.name.toName
+  let body : List Stmt' := [
+    .letM (.var `self) none ⟨.call (var `builtin.new) [cls] [], pos ⟩,
+    .expr ⟨.call (var init.name) args [], pos ⟩,
+    .ret ⟨ .var `self, pos ⟩
+    ]
+  return {
+    name := name
+    body := body.map fun b => Stmt.mk b pos
+    args := init.args.tail
+  }
+
+/-
+Generate an init function.
+
+If a class is declared with fields:
+
+  class C:
+    x : int
+    y : int = 1
+
+Then the default init function will have the form:
+
+  def __init__(self, x=None, y=1):
+   self.x = x
+   self.y = y
+   self.__post_init__()
+
+This function should work for both dataclasses and for NamedTuple.
+-/
+private def genInit (c : Class) : Cls Fun := do
+  let pos := { line := 0 : Pos }
+  let args := c.fields.map fun fld => Param.mk fld.name fld.expr
+  let vars := c.fields.map fun fld => Expr.mk (.var fld.name.toName) pos
+  let flds := c.fields.map fun fld => Expr.mk (.var (.str `self fld.name)) pos
+  let sets := (flds.zip vars).map fun (f,v) => Stmt.mk (.setM v f false) pos
+  let pifn := Expr.mk (.var (.str c.name "__post_init__")) pos
+  let post := Expr.mk (.call pifn [⟨.var `self, pos⟩] []) pos
+  let body := sets ++ [.mk (.expr post) pos]
+  return {
+    name := .str c.name "__init__"
+    body := body
+    args := .mk "self" none :: args
+  }
+
+-- Generate an empty post_init function
+private def genPostInit (c : Class) : Cls Fun :=
+  return {
+    name := .str c.name "__post_init__"
+    args := [.mk "self" none]
+  }
+
+private def isInit (f : Fun) : Bool :=
+  match f.name with
+  | .str _ "__init__" => true
+  | _ => false
+
+private def isPostInit (f : Fun) : Bool :=
+  match f.name with
+  | .str _ "__post_init__" => true
+  | _ => false
+
+/-
+Check for init and post_init functions, and if not found generate them.
+Also generate the constructor function for the class.
+-/
+private def ensureInit (c : Class) : Cls (List Fun) := do
+  let (init, fs) <- match c.methods.partition isInit with
+    | ([], fs) => pure ((<- genInit c),fs)
+    | (f::_, fs) => pure (f, fs)
+  let fs <- match c.methods.find? isPostInit with
+    | some _ => pure fs
+    | none => pure ((<- genPostInit c) :: fs)
+  return (<- genNew init) :: init :: fs
+
+private def qual (name : Name) (s : String) : String :=
+  (Lean.Name.str name s).toString
+
+/-
+Generate init functions, and move all of the class methods to the global
+function list. Also move all class fields to the global constants list.
+
+If a class is defined as:
+
+  class C:
+    x = 1
+    def f(): ...
+
+Then register the globals:
+
+  def C(x=1): ...
+  def C.__init__(self, x=1): ...
+  def C.__post_init__(self): ...
+  C.x = 1
+  def C.f(): ...
+
+For an object of type C, `x.f(...)` is syntactic sugar for `C.f(x,...)`.
+-/
+private def kernel (k : Kernel) : Cls Kernel := do
+  let mut vs := #[]
+  let mut fs := #[]
+  let mut cs := #[]
+  for c in k.cls do
+    let ms <- ensureInit c
+    let vars := c.fields.map fun kw => Keyword.mk (qual c.name kw.name) kw.expr
+    fs := fs.append ms.toArray
+    cs := cs.push { c with methods := [] }
+    vs := vs.append vars.toArray
+
+  return { k with
+    funs := k.funs ++ fs.toList
+    cls  := cs.toList
+  }
+
+-- TODO: capture warnings, make sure to call finalize
+def genClasses (k : Kernel) : Err Kernel :=
+  match (kernel k).run {} with
+  | .ok x _ => .ok x
+  | .error e _ => .error (toString e)

--- a/KLR/NKI/Pretty.lean
+++ b/KLR/NKI/Pretty.lean
@@ -159,7 +159,7 @@ instance : ToFormat Param where
 
 instance : ToFormat Fun where
   format f :=
-    f.name ++ args (f.args.map format) ++ ":" ++ .line ++
+    f.name.toString ++ args (f.args.map format) ++ ":" ++ .line ++
       stmts f.body
 
 instance : ToFormat Arg where
@@ -169,4 +169,4 @@ instance : ToFormat Kernel where
   format k :=
     .joinSep (k.globals.map format) .line ++ .line ++
     .joinSep (k.funs.map format) .line ++ .line ++
-    k.entry ++ args (k.args.map format)
+    k.entry.toString ++ args (k.args.map format)

--- a/KLR/Trace/NKI.lean
+++ b/KLR/Trace/NKI.lean
@@ -100,11 +100,11 @@ private def lookupName' (name : Name) : Trace Term := do
     match name with
     | .str .anonymous _ => throw "empty"
     | .str n id => (<- lookupName' n).attr id
-    | _ => throw s!"{name} not found"
+    | _ => throw s!"{name} not found."
 
 private def lookupName (name : Name) : Trace Term := do
   try lookupName' name
-  catch | "empty" => throw s!"{name} not found"
+  catch | "empty" => throw s!"{name} not found!"
         | e => throw e
 /-
 Best effort checks for slice overflow
@@ -376,7 +376,7 @@ private def filterGlobals (g : List Arg) : List Arg :=
 private def globals (k : Kernel) : Trace Unit := do
   let s <- get
   for f in k.funs do
-    let n := f.name.toName
+    let n := f.name
     if not (s.globals.contains n) && shouldKeep n then
       extend_global n (.source f)
   for g in filterGlobals k.globals do
@@ -418,7 +418,7 @@ def traceKernel (k : Kernel) : Trace Core.Kernel := do
       let inputs := Core.tensors inputs
       let outputs := Core.tensors $ <- lowerRes res
       return {
-        name := k.entry
+        name := k.entry.toString
         inputs := inputs
         outputs := outputs
         body := (<- get).body.toList

--- a/KLR/Trace/Python.lean
+++ b/KLR/Trace/Python.lean
@@ -26,6 +26,9 @@ Python related builtins
 namespace KLR.Trace
 open Core
 
+nki builtin.new (cls : String) := do
+  throw s!"new {cls} not implemented"
+
 nki builtin.op.negate (t : Term) := do
   match t with
   | .int x => return .int x.neg
@@ -46,7 +49,7 @@ private partial def termStr : Term -> Trace String
   | .module name => return name.toString
   | .builtin name _ => return name.toString
   | .ref name _ => do termStr (<- lookup name)
-  | .source f => return f.name
+  | .source f => return f.name.toString
   | .cls c => return s!"<class {c}>"
   | .object c _ => return s!"<{c} object>"
   | .method .. => return "method"

--- a/KLR/Trace/Types.lean
+++ b/KLR/Trace/Types.lean
@@ -372,7 +372,7 @@ def tracer (g : List (Name × Term)) (m : Trace a) (showWarnings := true) : Err 
 where
   getMessages s := "\n".intercalate s.messages.toList ++ "\n"
   addWarnings s str :=
-    if showWarnings then addWarn s str else str ++
+    (if showWarnings then addWarn s str else str) ++
     getMessages s
   addWarn s str := s.warnings.foldl warnStr str
   warnStr str pw :=


### PR DESCRIPTION
This change adds a compiler pass to generate init and post_init functions for any classes that do not have them defined. The auto-generated functions are similar to data- and NamedTuple-classes in Python.