### PR TITLE
feat: add support for Enum subclasses

### DIFF
--- a/KLR/NKI/Basic.lean
+++ b/KLR/NKI/Basic.lean
@@ -171,6 +171,7 @@ instance : BEq Fun where
 @[serde tag = 14]
 structure Class where
   name : Name
+  bases : List Name
   decs : List Name
   fields : List Keyword
   methods : List Fun

--- a/interop/test/test_class.py
+++ b/interop/test/test_class.py
@@ -105,6 +105,18 @@ def dynamic1():
   e.x = 1
   assert e.x == 1
 
+# test class fields
+
+def cls_fields1():
+  assert A.x == 1
+
+def cls_fields2():
+  assert C.b.x == 1
+
+def cls_methods():
+  a = A()
+  A.check(a, 1, None)
+
 # test each function in turn
 @pytest.mark.parametrize("f", [
   init1,
@@ -120,10 +132,34 @@ def dynamic1():
   init_c1,
   init_d1,
   dynamic1,
+  cls_fields1,
+  cls_fields2,
+  cls_methods,
   ])
 def test_succeed(f):
   F = Kernel(f)   # parse python
   F.specialize()
+  F.trace("tmp.klr")
+  os.remove("tmp.klr")
+
+
+# Boundary crossing
+# Check objects that originate from Python
+
+def cross1(a):
+  assert a.x == 1
+  assert a.y == None
+
+# test each function in turn
+@pytest.mark.parametrize("f", [
+  cross1,
+  ])
+def test_crossing(f):
+  F = Kernel(f)   # parse python
+  a = A()
+  a.x = 1
+  a.y = None
+  F.specialize((a,))
   F.trace("tmp.klr")
   os.remove("tmp.klr")
 
@@ -138,9 +174,13 @@ def bad_attribute():
   a = A()
   a.unknown
 
+def bad_cls_attribute():
+  a.y
+
 @pytest.mark.parametrize("f", [
   bad_init1,
   bad_attribute,
+  bad_cls_attribute
 ])
 def test_fails(f):
   with pytest.raises(Exception):

--- a/interop/test/test_enum.py
+++ b/interop/test/test_enum.py
@@ -1,0 +1,86 @@
+# This file exercises the Lean partial evaluator with
+# a set of basic unit tests. Each function is parsed,
+# handed to Lean, where it is checked and reduced to KLR.
+
+import os
+import pytest
+
+from enum import Enum
+from klr.frontend import Kernel
+
+# Success cases
+# (these functions should load and trace to KLR)
+
+class E(Enum):
+  x = 1
+  y = 2
+  z = 3
+
+  def f(self):
+    print(self.name + " " + str(self.value))
+
+def enum1():
+  e = E(name="x", value=1)
+  assert e.name == "x"
+  assert e.value == 1
+
+def enum2():
+  e = E.x
+  assert e.name == "x"
+  assert e.value == 1
+
+def enum3():
+  assert E.y.name == "y"
+  assert E.y.value == 2
+
+def enum4():
+  assert E.z.name == "z"
+  assert E.z.value == 3
+
+def enumEq1():
+  assert E.x == E.x
+
+def enumEq2():
+  assert E.x != E.y
+
+def enumEq3():
+  assert E.y != E.z
+
+# test each function in turn
+@pytest.mark.parametrize("f", [
+  enum1,
+  enum2,
+  enum3,
+  enum4,
+  enumEq1,
+  enumEq2,
+  enumEq3,
+  ])
+def test_succeed(f):
+  F = Kernel(f)   # parse python
+  F.specialize()
+  F.trace("tmp.klr")
+  os.remove("tmp.klr")
+
+
+# Boundary crossing
+# Check objects that originate from Python
+
+def cross1(e):
+  assert e.name == "x"
+  assert e.value == 1
+
+def cross2(e):
+  # technically this reference is crossing
+  assert E.x.x.name == "x"
+
+# test each function in turn
+@pytest.mark.parametrize("f", [
+  cross1,
+  cross2,
+  ])
+def test_crossing(f):
+  F = Kernel(f)   # parse python
+  F.specialize((E.x,))
+  F.trace("tmp.klr")
+  os.remove("tmp.klr")


### PR DESCRIPTION
This change adds support for Python Enum classes.  A simple compiler pass performs a similar translation to enum classes as what Python does dynamically. Basically, all class fields become instances of the class initialized with their previous value.