### PR TITLE
feat: add support for f-strings

### DIFF
--- a/KLR/NKI/Annotations.lean
+++ b/KLR/NKI/Annotations.lean
@@ -70,6 +70,8 @@ private def expr' (e' : Expr') : Ann Expr' :=
   | .ifExp c t f => return .ifExp (<- expr c) (<- expr t) (<- expr f)
   | .call f args kws => return .call (<- expr f) (<- exprs args) (<- kws.mapM keyword)
   | .object c fs => return .object c (<- fs.mapM keyword)
+  | .format e r => return .format (<- expr e) r
+  | .joined es => return .joined (<- exprs es)
   termination_by sizeOf e'
 
 private def optExpr (oe : Option Expr) : Ann (Option Expr) :=

--- a/KLR/NKI/Basic.lean
+++ b/KLR/NKI/Basic.lean
@@ -83,6 +83,8 @@ inductive Expr' where
   | ifExp (test tru fls : Expr)
   | call (f: Expr) (args: List Expr) (keywords : List Keyword)
   | object (cls : Name) (fields : List Keyword)
+  | format (expr : Expr) (repr : Bool)
+  | joined (es : List Expr)
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 @[serde tag = 5]

--- a/KLR/NKI/Pretty.lean
+++ b/KLR/NKI/Pretty.lean
@@ -75,6 +75,8 @@ private def expr' (e : Expr') (nested : Bool := false) : Format :=
   | .ifExp c t f => parens (expr t ++ " if " ++ expr c ++ " else " ++ expr f)
   | .call f xs kws => expr f ++ args (xs.map (expr (nested := true)) ++ kws.map keyword)
   | .object c fs => c.toString ++ args (fs.map keyword)
+  | .format e _ => braces (expr e)
+  | .joined es => "\"" ++ (.join (es.map expr)) ++ "\""
   termination_by sizeOf e
 
 private def exprOpt (oe : Option Expr) : Format :=

--- a/KLR/NKI/Simplify.lean
+++ b/KLR/NKI/Simplify.lean
@@ -213,6 +213,13 @@ private def expr' (e' : Python.Expr') : Simplify Expr' :=
       return .call f args kws
   | .starred .. => throw "tuple expansion is not supported"
   | .object c fs => return rewriteObj c.toName (<- keywords fs)
+  | .format e r => do
+      let r <- match r with
+        | none | some 97 | some 115 => pure false  -- none or 'a' or 's'
+        | some 114 => pure true -- 'r'
+        | some c => throw s!"unsupported conversion specifier {c}"
+      return .format (<- expr e) r
+  | .joined es => return .joined (<- exprs es)
   termination_by sizeOf e'
 
 private def index (e : Python.Expr) : Simplify Index := do

--- a/KLR/Python.lean
+++ b/KLR/Python.lean
@@ -114,6 +114,8 @@ inductive Expr' where
   | call (f: Expr) (args: List Expr) (keywords : List Keyword)
   | starred (e : Expr) (ctx : Ctx)
   | object (cls : String) (fields : List Keyword)
+  | format (e : Expr) (conv : Option Nat)
+  | joined (es : List Expr)
   deriving BEq, FromCBOR, FromJson, FromSexp, Repr, ToCBOR, ToJson, ToSexp
 
 @[serde tag = 9]

--- a/KLR/Trace/Lang.lean
+++ b/KLR/Trace/Lang.lean
@@ -86,7 +86,7 @@ nki builtin.lang.program_ndim := do
   lookup (nl "_program_ndim")
 
 nki builtin.lang.ds (start : Int) (size : Int) := do
-  return .mgItem start (start + size) 1
+  return .slice start (start + size) (some 1)
 
 -- We can't change the variable names to add an "_" or the macros will
 -- not resolve user parameters correctly.

--- a/KLR/Trace/NKI.lean
+++ b/KLR/Trace/NKI.lean
@@ -44,11 +44,6 @@ def NKIEnv : List (Name × Term) :=
   , const_int (.str (nisa "nc_version") "gen1") 1
   , const_int (.str (nisa "nc_version") "gen2") 2
   , const_int (.str (nisa "nc_version") "gen3") 3
-  , (nl "mgrid", .mgrid)
-  -- , const_var (nl "sbuf")
-  -- , const_var (nl "shared_hbm")
-  -- , const_var (nl "less")
-  -- , const_var (nisa "tensor_engine")
   -- engines
   , const_var (nisa "unknown_engine")
   , const_var (nisa "tensor_engine")
@@ -195,6 +190,14 @@ partial def expr' (e' : Expr') : Trace Term := do
       let name <- genName `obj
       extend_global name (.object c fs.toArray)
       return .ref name (.object c)
+  | .format e false => return .string (<- (<- expr e).toStr)
+  | .format e true => return .string (reprStr (<- expr e))
+  | .joined es =>
+      let es <- es.mapM expr
+      let strs <- es.mapM fun
+        | .string s => pure s
+        | _ => throw "internal error: non-string found in f-string elaboration"
+      return .string (.join strs)
 
 partial def optInt (e : Option Expr) : Trace (Option Int) := do
   match e with

--- a/KLR/Trace/Python.lean
+++ b/KLR/Trace/Python.lean
@@ -42,35 +42,8 @@ nki builtin.op.invert (t : Term) := do
 nki builtin.python.slice (b : Int) (e : Int) (s : Int) := do
   return .slice b e s
 
-private partial def termStr : Term -> Trace String
-  | .module name => return name.toString
-  | .builtin name _ => return name.toString
-  | .ref name _ => do termStr (<- lookup name)
-  | .source f => return f.name.toString
-  | .cls c => return s!"<class {c}>"
-  | .object c _ => return s!"<{c} object>"
-  | .method .. => return "method"
-  | .var name => do termStr (<- lookup name)
-  | .none => return "None"
-  | .bool true => return "True"
-  | .bool false => return "False"
-  | .int i => return toString i
-  | .float f => return toString f
-  | .string s => return s
-  | .access .. => return "<Access>"
-  | .tuple ts => return "("++ ",".intercalate (<- ts.mapM termStr) ++")"
-  | .list ts => return "["++ ",".intercalate (<- ts.toList.mapM termStr) ++"]"
-  | .dict _ => return "<dict>"
-  | .ellipsis => return "..."
-  | .slice .. => return "<slice>"
-  | .dynamic .. => return "<dynamic>"
-  | .pointer .. => return "<ptr>"
-  | .mgrid => return "<mgrid>"
-  | .mgItem .. => return "<mgrid_item>"
-  | .tensor .. => return "<tensor>"
-
 nki builtin.python.print (t : Term) := do
-  message (<- termStr t)
+  message (<- t.toStr)
   return .none
 
 nki builtin.python.len (t : Term) := do
@@ -86,7 +59,7 @@ nki builtin.python.min (a : Term) (b : Term) := do
   | _, _ => throw "invalid arguments"
 
 nki builtin.python.str (t : Term) := do
-  return .string (<- termStr t)
+  return .string (<- t.toStr)
 
 nki builtin.python.bool (t : Term) := do
  return .bool (<- t.isTrue)

--- a/interop/klr/lean_ast.h
+++ b/interop/klr/lean_ast.h
@@ -42,6 +42,8 @@ lean_object* Python_Expr_ifExp(lean_object*,lean_object*,lean_object*);
 lean_object* Python_Expr_call(lean_object*,lean_object*,lean_object*);
 lean_object* Python_Expr_starred(lean_object*,uint8_t);
 lean_object* Python_Expr_object(lean_object*,lean_object*);
+lean_object* Python_Expr_format(lean_object*,lean_object*);
+lean_object* Python_Expr_joined(lean_object*);
 extern uint8_t Python_UnaryOp_invert;
 extern uint8_t Python_UnaryOp_not;
 extern uint8_t Python_UnaryOp_uadd;

--- a/interop/test/test_fstr.py
+++ b/interop/test/test_fstr.py
@@ -1,0 +1,52 @@
+# This file exercises the Lean partial evaluator with
+# a set of basic unit tests. Each function is parsed,
+# handed to Lean, where it is checked and reduced to KLR.
+
+import os
+import pytest
+import neuronxcc.nki.typing as nt
+
+from klr.frontend import Kernel
+
+# Success cases
+# (these functions should load and trace to KLR)
+
+class A:
+  x : int = 1
+  y : bool = True
+
+def fstr1():
+  assert f"hello" == "hello"
+
+def fstr2():
+  a = A()
+  assert f"{a}" == "A(x:1,y:True)"
+
+def fstr3():
+  assert f"{1} {1+2} {'a'}" == "1 3 a"
+
+def fstr4():
+  assert f"{[1,2,3]}" == "[1,2,3]"
+
+def fstr5():
+  assert f"{(1,2,3)}" == "(1,2,3)"
+
+def fstr6():
+  x = {'a':1,'b':2}
+  assert f"{x}" == "{a:1,b:2}"
+
+# test each function in turn
+@pytest.mark.parametrize("f", [
+  fstr1,
+  fstr2,
+  fstr3,
+  fstr4,
+  fstr5,
+  fstr6,
+  ])
+def test_succeed(f):
+  t = nt.tensor("float32", (10,10,10))
+  F = Kernel(f)   # parse python
+  F.specialize()
+  F.trace("tmp.klr")
+  os.remove("tmp.klr")


### PR DESCRIPTION
This change adds support for Python-style f-strings. This implementation does not support format specifiers, but it does support the repr conversion tag.  In the case of repr-conversion, we use the Lean repr format.