### PR TITLE
fix: reduce cmd was not properly parsing

### DIFF
--- a/KLR/Trace/FromNKI.lean
+++ b/KLR/Trace/FromNKI.lean
@@ -323,8 +323,16 @@ instance : FromNKI ActivationFunc where
 
 instance : FromNKI AccumCmd where
   fromNKI? t :=
-    let err := .error "expecting activation function type"
+    let err := .error s!"expecting accumulator command (idle, reset, reduce, reset_reduce), got {repr t}"
     match t with
+    | .object `nki.isa.reduce_cmd vs
+    | .object `neuronxcc.nki.isa.reduce_cmd vs =>
+      match AA.lookup? vs "name" with
+      | some (.string "idle") => return .Idle
+      | some (.string "reset") => return .Zero
+      | some (.string "reduce") => return .Accumulate
+      | some (.string "reset_reduce") => return .ZeroAccumulate
+      | _ => err
     | .var name =>
       match name with
       | `neuronxcc.nki.isa.reduce_cmd.idle => return .Idle

--- a/interop/neuronxcc/nki/isa/__init__.py
+++ b/interop/neuronxcc/nki/isa/__init__.py
@@ -1,3 +1,4 @@
+from enum import Enum
 # KLR implemetations of NKI ISA APIs
 
 from enum import Enum
@@ -21,3 +22,11 @@ def sbuf_raw_ptr(address, size):
   p_end = p_start + p_size
   f_end = f_start + f_size
   return sbuf[p_start:p_end, f_start:f_end]
+
+class reduce_cmd(Enum):
+  """Engine Register Reduce commands """
+  idle = 0
+  reset = 1
+  reset_reduce = 2
+  reduce = 3
+  load_reduce = 4


### PR DESCRIPTION
Since we are parsing objects now, reduce_cmd comes through as an object and not string. Let's fix that