### PR TITLE
fix: enum constructor generated incorrectly

### DIFF
--- a/KLR/Trace/NKI.lean
+++ b/KLR/Trace/NKI.lean
@@ -420,8 +420,6 @@ over anything found during parsing.
 -/
 
 private def shouldKeep : Name -> Bool
-  | .str `neuronxcc.nki._pre_prod_kernels _ => true
-  | .str `neuronxcc _ => false
   | .str `numpy _ => false
   | .str n _ => shouldKeep n
   | _ => true

--- a/KLR/Trace/Term.lean
+++ b/KLR/Trace/Term.lean
@@ -428,7 +428,10 @@ private def pattern (a : Access) : Trace Term := do
 
 def Term.attr (t : Term) (id : String) : Trace Term :=
   match t with
-  | .module n | .var n => lookup (.str n id)
+  | .module n
+  | .builtin n _
+  | .source { name := n, ..}
+  | .var n => lookup (.str n id)
   | .ref _ .list =>
       match id with
       | "append"

--- a/interop/neuronxcc/nki/isa/__init__.py
+++ b/interop/neuronxcc/nki/isa/__init__.py
@@ -1,5 +1,13 @@
 # KLR implemetations of NKI ISA APIs
 
+from enum import Enum
+class reduce_cmd(Enum):
+  """Engine Register Reduce commands"""
+  idle = 0
+  reset = 1
+  reset_reduce = 3
+  reduce = 2
+
 def psum_raw_ptr(address, size):
   p_start, f_start = address
   p_size, f_size = size


### PR DESCRIPTION
This change fixes a bug in the generation of enum constructors. We also remove the limitation on importing definitions from neuronxcc namespace.